### PR TITLE
workflow: Align API and Workflow implementation

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -32,7 +32,7 @@ type API[Type any, Status StatusType] interface {
 	// return ErrWorkflowNotRunning or ErrStatusProvidedNotConfigured to indicate that it cannot begin to schedule. All
 	// schedule errors will be retried indefinitely. The same options are available for Schedule as they are
 	// for Trigger.
-	Schedule(ctx context.Context, foreignID string, startingStatus Status, spec string, opts ...ScheduleOption[Type, Status]) error
+	Schedule(foreignID string, startingStatus Status, spec string, opts ...ScheduleOption[Type, Status]) error
 
 	// Await is a blocking call that returns the typed Record when the workflow of the specified run ID reaches the
 	// specified status.

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -20,6 +20,9 @@ import (
 	"github.com/luno/workflow/adapters/memtimeoutstore"
 )
 
+// Ensures that workflow.Workflow always implements workflow.API
+var _ workflow.API[MyType, status] = (*workflow.Workflow[MyType, status])(nil)
+
 type MyType struct {
 	UserID      int64
 	Profile     string


### PR DESCRIPTION
Enforcing the alignment of these two. I think I previously didn't do it as they were generic but its simple enough to add to a test file. Will break tests passing if they dont align as opposed to creating a satus type in the workflow package just for this enforcement. Currently nothing uses workflow.API but I believe there is value here to use it in testing when you dont want the actual workflow running.