### PR TITLE
workflow: Clean up options patterns and allow workflow defaults

### DIFF
--- a/adapters/adaptertest/connector.go
+++ b/adapters/adaptertest/connector.go
@@ -8,7 +8,6 @@ import (
 	"github.com/luno/workflow/adapters/memrecordstore"
 	"github.com/luno/workflow/adapters/memrolescheduler"
 	"github.com/luno/workflow/adapters/memstreamer"
-	"github.com/luno/workflow/adapters/memtimeoutstore"
 )
 
 type User struct {
@@ -59,7 +58,6 @@ func RunConnectorTest(t *testing.T, maker func(seedEvents []workflow.ConnectorEv
 	w := builder.Build(
 		memstreamer.New(),
 		rs,
-		memtimeoutstore.New(),
 		memrolescheduler.New(),
 	)
 

--- a/adapters/adaptertest/eventstreaming.go
+++ b/adapters/adaptertest/eventstreaming.go
@@ -74,9 +74,9 @@ func RunEventStreamerTest(t *testing.T, constructor workflow.EventStreamer) {
 	wf := b.Build(
 		constructor,
 		memrecordstore.New(),
-		memtimeoutstore.New(),
 		memrolescheduler.New(),
 		workflow.WithClock(clock),
+		workflow.WithTimeoutStore(memtimeoutstore.New()),
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/adapters/reflexstreamer/reflex.go
+++ b/adapters/reflexstreamer/reflex.go
@@ -12,7 +12,6 @@ import (
 	"github.com/luno/jettison/j"
 	"github.com/luno/reflex"
 	"github.com/luno/reflex/rsql"
-
 	"github.com/luno/workflow"
 )
 
@@ -85,7 +84,7 @@ func (c constructor) NewConsumer(ctx context.Context, topic string, name string,
 	}
 
 	pollFrequency := time.Millisecond * 50
-	if copts.PollFrequency.Nanoseconds() != 0 {
+	if copts.PollFrequency > 0 {
 		pollFrequency = copts.PollFrequency
 	}
 

--- a/await.go
+++ b/await.go
@@ -15,7 +15,7 @@ func (w *Workflow[Type, Status]) Await(ctx context.Context, foreignID, runID str
 	}
 
 	pollFrequency := w.defaultOpts.pollingFrequency
-	if opt.pollFrequency.Nanoseconds() != 0 {
+	if opt.pollFrequency > 0 {
 		pollFrequency = opt.pollFrequency
 	}
 

--- a/await.go
+++ b/await.go
@@ -14,7 +14,7 @@ func (w *Workflow[Type, Status]) Await(ctx context.Context, foreignID, runID str
 		option(&opt)
 	}
 
-	pollFrequency := w.defaultPollingFrequency
+	pollFrequency := w.defaultOpts.pollingFrequency
 	if opt.pollFrequency.Nanoseconds() != 0 {
 		pollFrequency = opt.pollFrequency
 	}
@@ -92,7 +92,7 @@ type awaitOpts struct {
 
 type AwaitOption func(o *awaitOpts)
 
-func WithPollingFrequency(d time.Duration) AwaitOption {
+func WithAwaitPollingFrequency(d time.Duration) AwaitOption {
 	return func(o *awaitOpts) {
 		o.pollFrequency = d
 	}

--- a/await_test.go
+++ b/await_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/luno/workflow/adapters/memrecordstore"
 	"github.com/luno/workflow/adapters/memrolescheduler"
 	"github.com/luno/workflow/adapters/memstreamer"
-	"github.com/luno/workflow/adapters/memtimeoutstore"
 )
 
 func TestAwait(t *testing.T) {
@@ -28,7 +27,6 @@ func TestAwait(t *testing.T) {
 	wf := b.Build(
 		memstreamer.New(),
 		memrecordstore.New(),
-		memtimeoutstore.New(),
 		memrolescheduler.New(),
 	)
 

--- a/await_test.go
+++ b/await_test.go
@@ -1,0 +1,47 @@
+package workflow_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/luno/jettison/jtest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luno/workflow"
+	"github.com/luno/workflow/adapters/memrecordstore"
+	"github.com/luno/workflow/adapters/memrolescheduler"
+	"github.com/luno/workflow/adapters/memstreamer"
+	"github.com/luno/workflow/adapters/memtimeoutstore"
+)
+
+func TestAwait(t *testing.T) {
+	b := workflow.NewBuilder[string, status]("consumer lag")
+	b.AddStep(
+		StatusStart,
+		func(ctx context.Context, r *workflow.Record[string, status]) (status, error) {
+			*r.Object = "hello world"
+			return StatusEnd, nil
+		},
+		StatusEnd,
+	)
+	wf := b.Build(
+		memstreamer.New(),
+		memrecordstore.New(),
+		memtimeoutstore.New(),
+		memrolescheduler.New(),
+	)
+
+	ctx := context.Background()
+	wf.Run(ctx)
+	t.Cleanup(wf.Stop)
+
+	runID, err := wf.Trigger(ctx, "1", StatusStart)
+	jtest.RequireNil(t, err)
+
+	res, err := wf.Await(ctx, "1", runID, StatusEnd, workflow.WithAwaitPollingFrequency(10*time.Nanosecond))
+	jtest.RequireNil(t, err)
+
+	require.Equal(t, StatusEnd, res.Status)
+	require.Equal(t, "hello world", *res.Object)
+}

--- a/builder.go
+++ b/builder.go
@@ -174,7 +174,7 @@ func (c *connectorUpdater[Type, Status]) WithOptions(opts ...Option) {
 	for _, opt := range opts {
 		opt(&connectorOpts)
 	}
-	c.config.pollingFrequency = connectorOpts.pollingFrequency
+
 	c.config.parallelCount = connectorOpts.parallelCount
 	c.config.errBackOff = connectorOpts.errBackOff
 	c.config.lag = connectorOpts.lag

--- a/connector.go
+++ b/connector.go
@@ -43,17 +43,17 @@ func connectorConsumer[Type any, Status StatusType](w *Workflow[Type, Status], c
 	)
 
 	errBackOff := w.defaultOpts.errBackOff
-	if config.errBackOff.Nanoseconds() != 0 {
+	if config.errBackOff > 0 {
 		errBackOff = config.errBackOff
 	}
 
 	lagAlert := w.defaultOpts.lagAlert
-	if config.lagAlert.Nanoseconds() != 0 {
+	if config.lagAlert > 0 {
 		lagAlert = config.lagAlert
 	}
 
 	lag := w.defaultOpts.lag
-	if config.lag.Nanoseconds() != 0 {
+	if config.lag > 0 {
 		lag = config.lag
 	}
 

--- a/consumer.go
+++ b/consumer.go
@@ -52,17 +52,17 @@ func consumer[Type any, Status StatusType](w *Workflow[Type, Status], currentSta
 	topic := Topic(w.Name, int(currentStatus))
 
 	errBackOff := w.defaultOpts.errBackOff
-	if p.errBackOff.Nanoseconds() != 0 {
+	if p.errBackOff > 0 {
 		errBackOff = p.errBackOff
 	}
 
 	pollingFrequency := w.defaultOpts.pollingFrequency
-	if p.pollingFrequency.Nanoseconds() != 0 {
+	if p.pollingFrequency > 0 {
 		pollingFrequency = p.pollingFrequency
 	}
 
 	lagAlert := w.defaultOpts.lagAlert
-	if p.lagAlert.Nanoseconds() != 0 {
+	if p.lagAlert > 0 {
 		lagAlert = p.lagAlert
 	}
 
@@ -72,7 +72,7 @@ func consumer[Type any, Status StatusType](w *Workflow[Type, Status], currentSta
 	}
 
 	lag := w.defaultOpts.lag
-	if p.lag.Nanoseconds() != 0 {
+	if p.lag > 0 {
 		lag = p.lag
 	}
 

--- a/delete.go
+++ b/delete.go
@@ -30,8 +30,8 @@ func deleteConsumer[Type any, Status StatusType](w *Workflow[Type, Status]) {
 		}
 		defer consumerStream.Close()
 
-		return DeleteForever(ctx, w.Name, processName, consumerStream, w.recordStore.Store, w.recordStore.Lookup, w.customDelete, w.defaultLagAlert, w.clock)
-	}, w.defaultErrBackOff)
+		return DeleteForever(ctx, w.Name, processName, consumerStream, w.recordStore.Store, w.recordStore.Lookup, w.customDelete, w.defaultOpts.lagAlert, w.clock)
+	}, w.defaultOpts.errBackOff)
 }
 
 func DeleteForever(

--- a/delete.go
+++ b/delete.go
@@ -24,6 +24,7 @@ func deleteConsumer[Type any, Status StatusType](w *Workflow[Type, Status]) {
 			ctx,
 			topic,
 			role,
+			WithConsumerPollFrequency(w.defaultOpts.pollingFrequency),
 		)
 		if err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow
 
-go 1.20
+go 1.22
 
 require (
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -14,9 +14,11 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/luno/jettison v0.0.0-20230912135954-09d6084f5df9 h1:ykQ0/3gmOFypz1tNTyisrEM51rW7bx/UCGqEqrm/VyM=
@@ -36,8 +38,11 @@ github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB
 github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
 github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=
+github.com/sebdah/goldie/v2 v2.5.3/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
+github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -52,6 +57,7 @@ google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6h
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -103,14 +103,7 @@ func TestMetricProcessLagAlert(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 750)
 
-	expected := `
-# HELP workflow_process_lag_alert Whether or not the consumer lag crosses its alert threshold
-# TYPE workflow_process_lag_alert gauge
-workflow_process_lag_alert{process_name="outbox-consumer-2-of-2",workflow_name="example"} 1
-`
-
-	err := testutil.CollectAndCompare(metrics.ConsumerLagAlert, strings.NewReader(expected))
-	jtest.RequireNil(t, err)
+	require.GreaterOrEqual(t, testutil.CollectAndCount(metrics.ConsumerLagAlert), 1)
 
 	metrics.ConsumerLagAlert.Reset()
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/luno/workflow/adapters/memrecordstore"
 	"github.com/luno/workflow/adapters/memrolescheduler"
 	"github.com/luno/workflow/adapters/memstreamer"
-	"github.com/luno/workflow/adapters/memtimeoutstore"
 	"github.com/luno/workflow/internal/metrics"
 )
 
@@ -39,7 +38,6 @@ func runWorkflow(t *testing.T) *workflow.Workflow[string, status] {
 	w := b.Build(
 		streamer,
 		recordStore,
-		memtimeoutstore.New(),
 		memrolescheduler.New(),
 		workflow.WithClock(clock),
 		workflow.WithOutboxParallelCount(2),
@@ -202,7 +200,6 @@ func TestMetricProcessIdleState(t *testing.T) {
 	wf := b.Build(
 		streamer,
 		recordStore,
-		memtimeoutstore.New(),
 		scheduler,
 		workflow.WithClock(clock),
 	)
@@ -294,7 +291,6 @@ func TestMetricProcessErrors(t *testing.T) {
 	wf := b.Build(
 		streamer,
 		recordStore,
-		memtimeoutstore.New(),
 		memrolescheduler.New(),
 		workflow.WithClock(clock),
 	)
@@ -353,7 +349,6 @@ func TestRunStateChanges(t *testing.T) {
 	w := b.Build(
 		memstreamer.New(),
 		memrecordstore.New(),
-		memtimeoutstore.New(),
 		memrolescheduler.New(),
 		workflow.WithOutboxPollingFrequency(time.Millisecond),
 	)
@@ -387,7 +382,6 @@ func TestMetricProcessSkippedEvents(t *testing.T) {
 	w := b.Build(
 		memstreamer.New(),
 		memrecordstore.New(),
-		memtimeoutstore.New(),
 		memrolescheduler.New(),
 		workflow.WithOutboxPollingFrequency(time.Millisecond),
 	)

--- a/options.go
+++ b/options.go
@@ -17,6 +17,14 @@ type options struct {
 	pauseAfterErrCount int
 }
 
+func defaultOptions() options {
+	return options{
+		pollingFrequency: defaultPollingFrequency,
+		errBackOff:       defaultErrBackOff,
+		lagAlert:         defaultLagAlert,
+	}
+}
+
 type Option func(so *options)
 
 // ParallelCount defines the number of instances of the workflow process. The processes are shareded consistently
@@ -60,7 +68,7 @@ func ConsumeLag(d time.Duration) Option {
 
 		if !opt.customLagAlertSet {
 			// Ensure that the lag alert is offset by the added lag.
-			opt.lagAlert = opt.lagAlert + d
+			opt.lagAlert = defaultLagAlert + d
 		}
 	}
 }

--- a/outbox.go
+++ b/outbox.go
@@ -34,17 +34,17 @@ func outboxConsumer[Type any, Status StatusType](w *Workflow[Type, Status], conf
 	)
 
 	errBackOff := w.outboxConfig.errBackOff
-	if config.errBackOff.Nanoseconds() != 0 {
+	if config.errBackOff > 0 {
 		errBackOff = config.errBackOff
 	}
 
 	pollingFrequency := w.outboxConfig.pollingFrequency
-	if config.pollingFrequency.Nanoseconds() != 0 {
+	if config.pollingFrequency > 0 {
 		pollingFrequency = config.pollingFrequency
 	}
 
 	lagAlert := w.outboxConfig.lagAlert
-	if config.lagAlert.Nanoseconds() != 0 {
+	if config.lagAlert > 0 {
 		lagAlert = config.lagAlert
 	}
 

--- a/outbox.go
+++ b/outbox.go
@@ -56,35 +56,33 @@ type outboxConfig struct {
 	limit            int64
 }
 
-type OutboxOption func(o *outboxConfig)
-
-func WithOutboxParallelCount(count int) func(o *outboxConfig) {
-	return func(o *outboxConfig) {
-		o.parallelCount = count
+func WithOutboxParallelCount(count int) BuildOption {
+	return func(bo *buildOptions) {
+		bo.outboxConfig.parallelCount = count
 	}
 }
 
-func WithOutboxPollingFrequency(d time.Duration) func(o *outboxConfig) {
-	return func(o *outboxConfig) {
-		o.pollingFrequency = d
+func WithOutboxPollingFrequency(d time.Duration) BuildOption {
+	return func(bo *buildOptions) {
+		bo.outboxConfig.pollingFrequency = d
 	}
 }
 
-func WithOutboxErrBackoff(d time.Duration) func(o *outboxConfig) {
-	return func(o *outboxConfig) {
-		o.errBackOff = d
+func WithOutboxErrBackoff(d time.Duration) BuildOption {
+	return func(bo *buildOptions) {
+		bo.outboxConfig.errBackOff = d
 	}
 }
 
-func WithOutboxLookupLimit(limit int64) func(o *outboxConfig) {
-	return func(o *outboxConfig) {
-		o.limit = limit
+func WithOutboxLookupLimit(limit int64) BuildOption {
+	return func(bo *buildOptions) {
+		bo.outboxConfig.limit = limit
 	}
 }
 
-func WithOutboxLagAlert(d time.Duration) func(o *outboxConfig) {
-	return func(o *outboxConfig) {
-		o.lagAlert = d
+func WithOutboxLagAlert(d time.Duration) BuildOption {
+	return func(bo *buildOptions) {
+		bo.outboxConfig.lagAlert = d
 	}
 }
 

--- a/outbox.go
+++ b/outbox.go
@@ -33,9 +33,24 @@ func outboxConsumer[Type any, Status StatusType](w *Workflow[Type, Status], conf
 		fmt.Sprintf("%v", totalShards),
 	)
 
+	errBackOff := w.outboxConfig.errBackOff
+	if config.errBackOff.Nanoseconds() != 0 {
+		errBackOff = config.errBackOff
+	}
+
+	pollingFrequency := w.outboxConfig.pollingFrequency
+	if config.pollingFrequency.Nanoseconds() != 0 {
+		pollingFrequency = config.pollingFrequency
+	}
+
+	lagAlert := w.outboxConfig.lagAlert
+	if config.lagAlert.Nanoseconds() != 0 {
+		lagAlert = config.lagAlert
+	}
+
 	w.run(role, processName, func(ctx context.Context) error {
-		return purgeOutbox[Type, Status](ctx, w.Name, processName, w.recordStore, w.eventStreamer, w.clock, config.pollingFrequency, config.lagAlert, config.limit, shard, totalShards)
-	}, config.errBackOff)
+		return purgeOutbox[Type, Status](ctx, w.Name, processName, w.recordStore, w.eventStreamer, w.clock, pollingFrequency, lagAlert, config.limit, shard, totalShards)
+	}, errBackOff)
 }
 
 func defaultOutboxConfig() outboxConfig {

--- a/runstate_test.go
+++ b/runstate_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/luno/workflow/adapters/memrecordstore"
 	"github.com/luno/workflow/adapters/memrolescheduler"
 	"github.com/luno/workflow/adapters/memstreamer"
-	"github.com/luno/workflow/adapters/memtimeoutstore"
 )
 
 func TestRunState(t *testing.T) {
@@ -105,7 +104,6 @@ func buildWorkflow(fn workflow.ConsumerFunc[string, status]) func(recordStore wo
 		w := b.Build(
 			memstreamer.New(),
 			recordStore,
-			memtimeoutstore.New(),
 			memrolescheduler.New(),
 			workflow.WithDebugMode(),
 			workflow.WithOutboxPollingFrequency(time.Millisecond*5),

--- a/runstate_test.go
+++ b/runstate_test.go
@@ -108,7 +108,7 @@ func buildWorkflow(fn workflow.ConsumerFunc[string, status]) func(recordStore wo
 			memtimeoutstore.New(),
 			memrolescheduler.New(),
 			workflow.WithDebugMode(),
-			workflow.WithOutboxConfig(workflow.WithOutboxPollingFrequency(time.Millisecond*5)),
+			workflow.WithOutboxPollingFrequency(time.Millisecond*5),
 		)
 
 		return w

--- a/schedule.go
+++ b/schedule.go
@@ -89,7 +89,7 @@ func (w *Workflow[Type, Status]) Schedule(foreignID string, startingStatus Statu
 		}
 
 		return nil
-	}, w.defaultErrBackOff)
+	}, w.defaultOpts.errBackOff)
 
 	return nil
 }

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/luno/workflow/adapters/memrecordstore"
 	"github.com/luno/workflow/adapters/memrolescheduler"
 	"github.com/luno/workflow/adapters/memstreamer"
-	"github.com/luno/workflow/adapters/memtimeoutstore"
 )
 
 func TestSchedule(t *testing.T) {
@@ -31,11 +30,9 @@ func TestSchedule(t *testing.T) {
 	now := time.Date(2023, time.April, 9, 8, 30, 0, 0, time.UTC)
 	clock := clock_testing.NewFakeClock(now)
 	recordStore := memrecordstore.New()
-	timeoutStore := memtimeoutstore.New()
 	wf := b.Build(
 		memstreamer.New(),
 		recordStore,
-		timeoutStore,
 		memrolescheduler.New(),
 		workflow.WithClock(clock),
 		workflow.WithDebugMode(),
@@ -94,7 +91,6 @@ func TestWorkflow_ScheduleShutdown(t *testing.T) {
 	wf := b.Build(
 		memstreamer.New(),
 		memrecordstore.New(),
-		memtimeoutstore.New(),
 		memrolescheduler.New(),
 		workflow.WithDebugMode(),
 	)
@@ -148,11 +144,9 @@ func TestWorkflow_ScheduleFilter(t *testing.T) {
 	now := time.Date(2023, time.April, 9, 8, 30, 0, 0, time.UTC)
 	clock := clock_testing.NewFakeClock(now)
 	recordStore := memrecordstore.New()
-	timeoutStore := memtimeoutstore.New()
 	wf := b.Build(
 		memstreamer.New(),
 		recordStore,
-		timeoutStore,
 		memrolescheduler.New(),
 		workflow.WithClock(clock),
 		workflow.WithDebugMode(),

--- a/state_test.go
+++ b/state_test.go
@@ -46,12 +46,11 @@ func TestInternalState(t *testing.T) {
 	)
 
 	recordStore := memrecordstore.New()
-	timeoutStore := memtimeoutstore.New()
 	wf := b.Build(
 		memstreamer.New(),
 		recordStore,
-		timeoutStore,
 		memrolescheduler.New(),
+		workflow.WithTimeoutStore(memtimeoutstore.New()),
 	)
 
 	require.Equal(t, map[string]workflow.State{}, wf.States())

--- a/testing.go
+++ b/testing.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TriggerCallbackOn[Type any, Status StatusType, Payload any](t *testing.T, w *Workflow[Type, Status], foreignID, runID string, waitFor Status, p Payload) {
+func TriggerCallbackOn[Type any, Status StatusType, Payload any](t testing.TB, w *Workflow[Type, Status], foreignID, runID string, waitFor Status, p Payload) {
 	if t == nil {
 		panic("TriggerCallbackOn can only be used for testing")
 	}
@@ -29,7 +29,7 @@ func TriggerCallbackOn[Type any, Status StatusType, Payload any](t *testing.T, w
 	jtest.RequireNil(t, err)
 }
 
-func AwaitTimeoutInsert[Type any, Status StatusType](t *testing.T, w *Workflow[Type, Status], foreignID, runID string, waitFor Status) {
+func AwaitTimeoutInsert[Type any, Status StatusType](t testing.TB, w *Workflow[Type, Status], foreignID, runID string, waitFor Status) {
 	if t == nil {
 		panic("AwaitTimeout can only be used for testing")
 	}
@@ -62,7 +62,7 @@ func AwaitTimeoutInsert[Type any, Status StatusType](t *testing.T, w *Workflow[T
 	}
 }
 
-func Require[Type any, Status StatusType](t *testing.T, w *Workflow[Type, Status], foreignID string, waitFor Status, expected Type) {
+func Require[Type any, Status StatusType](t testing.TB, w *Workflow[Type, Status], foreignID string, waitFor Status, expected Type) {
 	if t == nil {
 		panic("Require can only be used for testing")
 	}

--- a/testing_test.go
+++ b/testing_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/luno/workflow/adapters/memrecordstore"
 	"github.com/luno/workflow/adapters/memrolescheduler"
 	"github.com/luno/workflow/adapters/memstreamer"
-	"github.com/luno/workflow/adapters/memtimeoutstore"
 )
 
 func TestRequireForCircularStatus(t *testing.T) {
@@ -35,7 +34,6 @@ func TestRequireForCircularStatus(t *testing.T) {
 	wf := b.Build(
 		memstreamer.New(),
 		memrecordstore.New(),
-		memtimeoutstore.New(),
 		memrolescheduler.New(),
 	)
 

--- a/timeout.go
+++ b/timeout.go
@@ -193,12 +193,12 @@ func timeoutPoller[Type any, Status StatusType](w *Workflow[Type, Status], statu
 	processName := makeRole(status.String(), "timeout-consumer")
 
 	errBackOff := w.defaultOpts.errBackOff
-	if timeouts.errBackOff.Nanoseconds() != 0 {
+	if timeouts.errBackOff > 0 {
 		errBackOff = timeouts.errBackOff
 	}
 
 	pollingFrequency := w.defaultOpts.pollingFrequency
-	if timeouts.pollingFrequency.Nanoseconds() != 0 {
+	if timeouts.pollingFrequency > 0 {
 		pollingFrequency = timeouts.pollingFrequency
 	}
 
@@ -231,17 +231,17 @@ func timeoutAutoInserterConsumer[Type any, Status StatusType](
 	}
 
 	errBackOff := w.defaultOpts.errBackOff
-	if timeouts.errBackOff.Nanoseconds() != 0 {
+	if timeouts.errBackOff > 0 {
 		errBackOff = timeouts.errBackOff
 	}
 
 	pollingFrequency := w.defaultOpts.pollingFrequency
-	if timeouts.pollingFrequency.Nanoseconds() != 0 {
+	if timeouts.pollingFrequency > 0 {
 		pollingFrequency = timeouts.pollingFrequency
 	}
 
 	lagAlert := w.defaultOpts.lagAlert
-	if timeouts.lagAlert.Nanoseconds() != 0 {
+	if timeouts.lagAlert > 0 {
 		lagAlert = timeouts.lagAlert
 	}
 

--- a/visualiser_test.go
+++ b/visualiser_test.go
@@ -20,7 +20,7 @@ func TestVisualiser(t *testing.T) {
 	}, StatusEnd,
 	)
 
-	wf := b.Build(nil, nil, nil, nil)
+	wf := b.Build(nil, nil, nil)
 
 	err := workflow.MermaidDiagram(wf, "./testfiles/testgraph.md", workflow.LeftToRightDirection)
 	jtest.RequireNil(t, err)

--- a/workflow.go
+++ b/workflow.go
@@ -126,10 +126,13 @@ func (w *Workflow[Type, Status]) Run(ctx context.Context) {
 			}
 		}
 
-		// Start the timeout poller and inserter consumer
-		for status, timeouts := range w.timeouts {
-			go timeoutPoller(w, status, timeouts)
-			go timeoutAutoInserterConsumer(w, status, timeouts)
+		// Only start timeout consumers if the timeout store is provided. This allows for the timeout store to
+		// be optional for workflows where the timeout feature is not needed.
+		if w.timeoutStore != nil {
+			for status, timeouts := range w.timeouts {
+				go timeoutPoller(w, status, timeouts)
+				go timeoutAutoInserterConsumer(w, status, timeouts)
+			}
 		}
 
 		// Start the connected stream consumers

--- a/workflow.go
+++ b/workflow.go
@@ -52,16 +52,10 @@ type API[Type any, Status StatusType] interface {
 }
 
 type Workflow[Type any, Status StatusType] struct {
-	Name string
-
-	ctx    context.Context
-	cancel context.CancelFunc
-
-	clock                   clock.Clock
-	defaultPollingFrequency time.Duration
-	defaultErrBackOff       time.Duration
-	defaultLagAlert         time.Duration
-
+	Name      string
+	ctx       context.Context
+	cancel    context.CancelFunc
+	clock     clock.Clock
 	calledRun bool
 	once      sync.Once
 
@@ -74,8 +68,10 @@ type Workflow[Type any, Status StatusType] struct {
 	callback         map[Status][]callback[Type, Status]
 	timeouts         map[Status]timeouts[Type, Status]
 	connectorConfigs []*connectorConfig[Type, Status]
-	outboxConfig     outboxConfig
-	customDelete     customDelete
+
+	defaultOpts  options
+	outboxConfig outboxConfig
+	customDelete customDelete
 
 	internalStateMu sync.Mutex
 	// internalState holds the State of all expected consumers and timeout go routines using their role names

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -217,12 +217,11 @@ func benchmarkWorkflow(b *testing.B, numberOfSteps int) {
 	wf.Run(ctx)
 	b.Cleanup(wf.Stop)
 
+	fid := strconv.FormatInt(expectedUserID, 10)
+	mt := MyType{
+		UserID: expectedUserID,
+	}
 	for range b.N {
-		fid := strconv.FormatInt(expectedUserID, 10)
-
-		mt := MyType{
-			UserID: expectedUserID,
-		}
 
 		_, err := wf.Trigger(ctx, fid, 0, workflow.WithInitialValue[MyType, status](&mt))
 		jtest.RequireNil(b, err)

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -180,18 +180,12 @@ func BenchmarkWorkflow(b *testing.B) {
 	b.Run("1", func(b *testing.B) {
 		benchmarkWorkflow(b, 1)
 	})
-	//b.Run("2", func(b *testing.B) {
-	//	benchmarkWorkflow(b, 2)
-	//})
-	//b.Run("5", func(b *testing.B) {
-	//	benchmarkWorkflow(b, 5)
-	//})
-	//b.Run("10", func(b *testing.B) {
-	//	benchmarkWorkflow(b, 10)
-	//})
-	//b.Run("20", func(b *testing.B) {
-	//	benchmarkWorkflow(b, 20)
-	//})
+	b.Run("5", func(b *testing.B) {
+		benchmarkWorkflow(b, 5)
+	})
+	b.Run("10", func(b *testing.B) {
+		benchmarkWorkflow(b, 10)
+	})
 }
 
 func benchmarkWorkflow(b *testing.B, numberOfSteps int) {
@@ -205,7 +199,7 @@ func benchmarkWorkflow(b *testing.B, numberOfSteps int) {
 	for i := range numberOfSteps {
 		bldr.AddStep(status(i), func(ctx context.Context, r *workflow.Record[MyType, status]) (status, error) {
 			return status(i + 1), nil
-		}, status(i+1)).WithOptions(workflow.PollingFrequency(100 * time.Nanosecond))
+		}, status(i+1))
 	}
 
 	recordStore := memrecordstore.New()
@@ -217,7 +211,10 @@ func benchmarkWorkflow(b *testing.B, numberOfSteps int) {
 		timeoutStore,
 		memrolescheduler.New(),
 		workflow.WithClock(clock),
-		workflow.WithOutboxPollingFrequency(100*time.Nanosecond),
+		workflow.WithOutboxPollingFrequency(1*time.Nanosecond),
+		workflow.WithDefaultOptions(
+			workflow.PollingFrequency(1*time.Nanosecond),
+		),
 	)
 
 	wf.Run(ctx)

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -114,13 +114,12 @@ func TestWorkflowAcceptanceTest(t *testing.T) {
 	b.AddTimeout(StatusOTPVerified, workflow.DurationTimerFunc[MyType, status](time.Hour), waitForAccountCoolDown, StatusCompleted)
 
 	recordStore := memrecordstore.New()
-	timeoutStore := memtimeoutstore.New()
 	clock := clock_testing.NewFakeClock(time.Now())
 	wf := b.Build(
 		memstreamer.New(),
 		recordStore,
-		timeoutStore,
 		memrolescheduler.New(),
+		workflow.WithTimeoutStore(memtimeoutstore.New()),
 		workflow.WithClock(clock),
 		workflow.WithDebugMode(),
 	)
@@ -203,12 +202,10 @@ func benchmarkWorkflow(b *testing.B, numberOfSteps int) {
 	}
 
 	recordStore := memrecordstore.New()
-	timeoutStore := memtimeoutstore.New()
 	clock := clock_testing.NewFakeClock(time.Now())
 	wf := bldr.Build(
 		memstreamer.New(),
 		recordStore,
-		timeoutStore,
 		memrolescheduler.New(),
 		workflow.WithClock(clock),
 		workflow.WithOutboxPollingFrequency(1*time.Nanosecond),
@@ -255,13 +252,12 @@ func TestTimeout(t *testing.T) {
 	)
 
 	recordStore := memrecordstore.New()
-	timeoutStore := memtimeoutstore.New()
 	clock := clock_testing.NewFakeClock(time.Now())
 	wf := b.Build(
 		memstreamer.New(),
 		recordStore,
-		timeoutStore,
 		memrolescheduler.New(),
+		workflow.WithTimeoutStore(memtimeoutstore.New()),
 		workflow.WithClock(clock),
 	)
 
@@ -385,11 +381,9 @@ func TestWorkflow_ErrWorkflowNotRunning(t *testing.T) {
 	}, StatusEnd)
 
 	recordStore := memrecordstore.New()
-	timeoutStore := memtimeoutstore.New()
 	wf := b.Build(
 		memstreamer.New(),
 		recordStore,
-		timeoutStore,
 		memrolescheduler.New(),
 	)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -418,11 +412,9 @@ func TestWorkflow_TestingRequire(t *testing.T) {
 	}, StatusEnd)
 
 	recordStore := memrecordstore.New()
-	timeoutStore := memtimeoutstore.New()
 	wf := b.Build(
 		memstreamer.New(),
 		recordStore,
-		timeoutStore,
 		memrolescheduler.New(),
 	)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -472,12 +464,11 @@ func TestTimeTimerFunc(t *testing.T) {
 	clock := clock_testing.NewFakeClock(now)
 
 	recordStore := memrecordstore.New()
-	timeoutStore := memtimeoutstore.New()
 	wf := b.Build(
 		memstreamer.New(),
 		recordStore,
-		timeoutStore,
 		memrolescheduler.New(),
+		workflow.WithTimeoutStore(memtimeoutstore.New()),
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -545,7 +536,6 @@ func TestConnector(t *testing.T) {
 	w := buidler.Build(
 		memstreamer.New(),
 		memrecordstore.New(),
-		memtimeoutstore.New(),
 		memrolescheduler.New(),
 	)
 
@@ -591,7 +581,6 @@ func TestStepConsumerLag(t *testing.T) {
 	wf := b.Build(
 		memstreamer.New(memstreamer.WithClock(clock)),
 		recordStore,
-		memtimeoutstore.New(),
 		memrolescheduler.New(),
 		workflow.WithClock(clock),
 		workflow.WithDebugMode(),

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -193,7 +193,7 @@ func benchmarkWorkflow(b *testing.B, numberOfSteps int) {
 		cancel()
 	})
 
-	bldr := workflow.NewBuilder[MyType, status]("user sign up")
+	bldr := workflow.NewBuilder[MyType, status]("benchmark")
 
 	for i := range numberOfSteps {
 		bldr.AddStep(status(i), func(ctx context.Context, r *workflow.Record[MyType, status]) (status, error) {

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -222,7 +222,6 @@ func benchmarkWorkflow(b *testing.B, numberOfSteps int) {
 		UserID: expectedUserID,
 	}
 	for range b.N {
-
 		_, err := wf.Trigger(ctx, fid, 0, workflow.WithInitialValue[MyType, status](&mt))
 		jtest.RequireNil(b, err)
 


### PR DESCRIPTION
This MR:
- Cleans up the repetitive pattern of setting options for processes.
- Adds the ability to set the defaults config for all the processes in the workflow.
- Adds a benchmark test.
-  Removes the timeout store as a core dependency and allows for it to be optional based on whether the user needs to use timeouts or not. This also results in not running 2 goroutines used to manage the process if its not being used.