### PR TITLE
workflow: Use int value for status filter to avoid generic assertion

### DIFF
--- a/adapters/adaptertest/recordstore.go
+++ b/adapters/adaptertest/recordstore.go
@@ -297,7 +297,7 @@ func testList(t *testing.T, factory func() workflow.RecordStore) {
 		}
 
 		for status, count := range config {
-			ls, err := store.List(ctx, workflowName, 0, 100, workflow.OrderTypeAscending, workflow.FilterByStatus(status))
+			ls, err := store.List(ctx, workflowName, 0, 100, workflow.OrderTypeAscending, workflow.FilterByStatus(int64(status)))
 			jtest.RequireNil(t, err)
 			require.Equal(t, count, len(ls))
 

--- a/filter.go
+++ b/filter.go
@@ -49,9 +49,9 @@ func FilterByForeignID(val string) RecordFilter {
 	}
 }
 
-func FilterByStatus[status StatusType](s status) RecordFilter {
+func FilterByStatus(status int64) RecordFilter {
 	return func(filters *recordFilters) {
-		i := strconv.FormatInt(int64(s), 10)
+		i := strconv.FormatInt(status, 10)
 		filters.byStatus = makeFilterValue(i)
 	}
 }

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,29 @@
+package workflow_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/luno/workflow"
+)
+
+func TestMakeFilter(t *testing.T) {
+	t.Run("Filter by RunState", func(t *testing.T) {
+		filter := workflow.MakeFilter(workflow.FilterByRunState(workflow.RunStateInitiated))
+		require.True(t, filter.ByRunState().Enabled, "Expected RunState filter to be enabled")
+		require.Equal(t, "1", filter.ByRunState().Value, "Expected RunState filter value to be 5")
+	})
+
+	t.Run("Filter by ForeignID", func(t *testing.T) {
+		filter := workflow.MakeFilter(workflow.FilterByForeignID("test value"))
+		require.True(t, filter.ByForeignID().Enabled, "Expected foreign ID filter to be enabled")
+		require.Equal(t, "test value", filter.ByForeignID().Value, "Expected foreign ID filter value to be 5")
+	})
+
+	t.Run("Filter by Status", func(t *testing.T) {
+		filter := workflow.MakeFilter(workflow.FilterByStatus(9))
+		require.True(t, filter.ByStatus().Enabled, "Expected status filter to be enabled")
+		require.Equal(t, "9", filter.ByStatus().Value, "Expected status filter value to be 5")
+	})
+}


### PR DESCRIPTION
This is to avoid having to refer to a specific status type in the context of dealing with the record store where generic types are not of a concern. At this level status should just be an `int` . Generics should never leak onto the adapter interfaces and should always be wire format.