### PR TITLE
readme: Update examples link to _examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ if err != nil {
 ```
 
 ### Detailed examples
-Head on over to [./examples](./examples) to get familiar with **callbacks**, **timeouts**, **testing**, **connectors** and
+Head on over to [./_examples](./_examples) to get familiar with **callbacks**, **timeouts**, **testing**, **connectors** and
  more about the syntax in depth 😊
 
 ---


### PR DESCRIPTION
The examples were moved to `_examples` so that they are ignored by the go tool. The README sadly was not informed.