### PR TITLE
reflexstreamer: Register fill gaps on clone

### DIFF
--- a/adapters/reflexstreamer/reflex.go
+++ b/adapters/reflexstreamer/reflex.go
@@ -130,7 +130,11 @@ func (c *Consumer) Recv(ctx context.Context) (*workflow.Event, workflow.Ack, err
 	for ctx.Err() == nil {
 		reflexEvent, err := c.streamClient.Recv()
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, errors.Wrap(err, "failed to receive event")
+		}
+
+		if len(reflexEvent.MetaData) == 0 {
+			continue
 		}
 
 		headers := make(map[workflow.Header]string)

--- a/adapters/reflexstreamer/reflex_test.go
+++ b/adapters/reflexstreamer/reflex_test.go
@@ -25,6 +25,44 @@ func TestStreamer(t *testing.T) {
 	adaptertest.RunEventStreamerTest(t, constructor)
 }
 
+func TestStreamerGapFiller(t *testing.T) {
+	eventsTable := rsql.NewEventsTableInt("workflow_events", rsql.WithEventMetadataField("metadata"))
+	dbc := ConnectForTesting(t)
+	cTable := rsql.NewCursorsTable("cursors")
+	_, err := dbc.Exec("insert into workflow_events set id=1, foreign_id=98327498324, timestamp=now(3), type=1, metadata=?;", "{}")
+	jtest.RequireNil(t, err)
+
+	_, err = dbc.Exec("insert into workflow_events set id=3, foreign_id=98579438574, timestamp=now(3), type=2, metadata=?;", "{}")
+	jtest.RequireNil(t, err)
+
+	constructor := reflexstreamer.New(dbc, dbc, eventsTable, cTable.ToStore(dbc))
+	consumer, err := constructor.NewConsumer(context.Background(), "", "")
+	jtest.RequireNil(t, err)
+
+	for range 2 {
+		_, ack, err := consumer.Recv(context.Background())
+		jtest.RequireNil(t, err)
+
+		err = ack()
+		jtest.RequireNil(t, err)
+	}
+
+	rows, err := dbc.Query("select `id`from workflow_events")
+	jtest.RequireNil(t, err)
+	defer rows.Close()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		err := rows.Scan(&id)
+		jtest.RequireNil(t, err)
+
+		ids = append(ids, id)
+	}
+
+	require.Equal(t, []int64{1, 2, 3}, ids)
+}
+
 func TestStreamFunc(t *testing.T) {
 	dbc := ConnectForTesting(t)
 	eventsTable := rsql.NewEventsTableInt("workflow_events", rsql.WithEventMetadataField("metadata"))


### PR DESCRIPTION
Currently rsql.Clone does not copy the gap fillers over so this forces a gap filler to be added once