### PR TITLE
workflow: Rename diagram creation function and signature

### DIFF
--- a/testdata/graph-visualisation.md
+++ b/testdata/graph-visualisation.md
@@ -5,7 +5,7 @@ title: Diagram of example Workflow
 stateDiagram-v2
 	direction LR
 	
-	Start-->Middle
-	Start-->End
-	Middle-->End
+	start-->middle
+	start-->end
+	middle-->end
 ```

--- a/visualiser_test.go
+++ b/visualiser_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/luno/jettison/jtest"
+	"github.com/stretchr/testify/require"
 
 	"github.com/luno/workflow"
 )
 
-func TestVisualiser(t *testing.T) {
+func TestCreateDiagram(t *testing.T) {
 	b := workflow.NewBuilder[string, status]("example")
 	b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[string, status]) (status, error) {
 		return StatusMiddle, nil
@@ -22,6 +23,12 @@ func TestVisualiser(t *testing.T) {
 
 	wf := b.Build(nil, nil, nil)
 
-	err := workflow.MermaidDiagram(wf, "./testdata/graph-visualisation.md", workflow.LeftToRightDirection)
+	err := workflow.CreateDiagram(wf, "./testdata/graph-visualisation.md", workflow.LeftToRightDirection)
 	jtest.RequireNil(t, err)
+}
+
+func TestCreateDiagramValidation(t *testing.T) {
+	w := (workflow.API[string, status])(nil)
+	err := workflow.CreateDiagram(w, "./testdata/should-not-exist.md", workflow.LeftToRightDirection)
+	require.Equal(t, err.Error(), "cannot create diagram for non-original workflow.Workflow type")
 }


### PR DESCRIPTION
This MR updates the diagram function from `MermaidDiagram` -> `CreateDiagram` which seems to be far more intuitive. Also a small bug where statuses that have spaces break the diagram is fixed in this MR.