### PR TITLE
workflow: Support json.Marshaler implementations for Require

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -4,11 +4,7 @@ import (
 	"encoding/json"
 )
 
+// Marshal create a single point of change if the encoding changes.
 func Marshal[T any](t *T) ([]byte, error) {
-	b, err := json.Marshal(t)
-	if err != nil {
-		return nil, err
-	}
-
-	return b, nil
+	return json.Marshal(t)
 }

--- a/testing_test.go
+++ b/testing_test.go
@@ -2,6 +2,8 @@ package workflow_test
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,24 +14,12 @@ import (
 	"github.com/luno/workflow/adapters/memstreamer"
 )
 
-func TestRequireForCircularStatus(t *testing.T) {
-	type Counter struct {
-		Count int
-	}
-
-	b := workflow.NewBuilder[Counter, status]("circular flow")
-	b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[Counter, status]) (status, error) {
-		r.Object.Count += 1
-		return StatusMiddle, nil
-	}, StatusMiddle)
-	b.AddStep(StatusMiddle, func(ctx context.Context, r *workflow.Run[Counter, status]) (status, error) {
-		if r.Object.Count < 2 {
-			return StatusStart, nil
-		}
-
-		r.Object.Count += 1
+func TestRequire(t *testing.T) {
+	b := workflow.NewBuilder[testCustomMarshaler, status]("circular flow")
+	b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[testCustomMarshaler, status]) (status, error) {
+		*r.Object = "Lower"
 		return StatusEnd, nil
-	}, StatusStart, StatusEnd)
+	}, StatusEnd)
 
 	wf := b.Build(
 		memstreamer.New(),
@@ -45,9 +35,14 @@ func TestRequireForCircularStatus(t *testing.T) {
 	_, err := wf.Trigger(ctx, fid, StatusStart)
 	require.Nil(t, err)
 
-	workflow.Require(t, wf, fid, StatusStart, Counter{Count: 0})
-	workflow.Require(t, wf, fid, StatusMiddle, Counter{Count: 1})
-	workflow.Require(t, wf, fid, StatusStart, Counter{Count: 1})
-	workflow.Require(t, wf, fid, StatusMiddle, Counter{Count: 2})
-	workflow.Require(t, wf, fid, StatusEnd, Counter{Count: 3})
+	workflow.Require(t, wf, fid, StatusEnd, "Lower")
+}
+
+// testCustomMarshaler is for testing and implements custom and weird behaviour via the
+// MarshalJSON method and this is to test that the Require function can successfully compare
+// the actual and expected by running them through the same encoding / decoding process.
+type testCustomMarshaler string
+
+func (t testCustomMarshaler) MarshalJSON() ([]byte, error) {
+	return json.Marshal(strings.ToLower(string(t)))
 }

--- a/testing_test.go
+++ b/testing_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestRequire(t *testing.T) {
-	b := workflow.NewBuilder[testCustomMarshaler, status]("circular flow")
+	b := workflow.NewBuilder[testCustomMarshaler, status]("test")
 	b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[testCustomMarshaler, status]) (status, error) {
 		*r.Object = "Lower"
 		return StatusEnd, nil

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -4,10 +4,5 @@ import "encoding/json"
 
 // Unmarshal create a single point of change if the decoding changes.
 func Unmarshal[T any](b []byte, t *T) error {
-	err := json.Unmarshal(b, t)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return json.Unmarshal(b, t)
 }

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -2,6 +2,7 @@ package workflow
 
 import "encoding/json"
 
+// Unmarshal create a single point of change if the decoding changes.
 func Unmarshal[T any](b []byte, t *T) error {
 	err := json.Unmarshal(b, t)
 	if err != nil {


### PR DESCRIPTION
I have started to see some json.Marshaler implementations and the testing util func `Require` needs to be provided with an object that has gone through the encode and decode process. To avoid the user needing to do this the Require func is being updated to take the provided expected data and encode and then decode it the same way the data in the workflow. This is a developer experience (DX) change at the heart of it as it's frustrating to need to adjust default zero values of objects or reformat underlying strings etc.