### PR TITLE
visualiser: Allow spacing in node names

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -1,5 +1,7 @@
 package graph
 
+import "slices"
+
 func New() *Graph {
 	return &Graph{
 		graph:      make(map[int][]int),
@@ -73,6 +75,21 @@ type Info struct {
 	StartingNodes []int
 	TerminalNodes []int
 	Transitions   []Transition
+}
+
+func (g *Graph) Nodes() []int {
+	var nodes []int
+	for node, ok := range g.validNodes {
+		if !ok {
+			continue
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	slices.Sort(nodes)
+
+	return nodes
 }
 
 func (g *Graph) Info() Info {

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -53,4 +53,8 @@ func TestGraph(t *testing.T) {
 		},
 	}
 	require.Equal(t, expected, actual)
+
+	actualNodes := g.Nodes()
+	expectedNodes := []int{1, 2, 3, 4, 5}
+	require.Equal(t, expectedNodes, actualNodes)
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,0 +1,16 @@
+package util
+
+import "unicode"
+
+func CamelToSpacing(s string) string {
+	var result []rune
+	for i, r := range s {
+		// If the character is uppercase and it's not the first character, add a space before it.
+		if unicode.IsUpper(r) && i > 0 {
+			result = append(result, ' ')
+		}
+		// Append the current character (it will preserve its case).
+		result = append(result, r)
+	}
+	return string(result)
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,31 @@
+package util_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/luno/workflow/internal/util"
+)
+
+func TestCamelToSpacing(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"camelCase", "camel Case"},
+		{"thisIsATest", "this Is A Test"},
+		{"helloWorld", "hello World"},
+		{"singleWord", "single Word"},
+		{"Lowercase", "Lowercase"}, // No change if no camel case
+		{"", ""},                   // Empty string case
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("case %v: %v", i+1, test.input), func(t *testing.T) {
+			result := util.CamelToSpacing(test.input)
+			require.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/testdata/graph-visualisation.md
+++ b/testdata/graph-visualisation.md
@@ -5,7 +5,12 @@ title: Diagram of example Workflow
 stateDiagram-v2
 	direction LR
 	
-	start-->middle
-	start-->end
-	middle-->end
+	9: Start
+	10: Middle
+	11: End
+
+	
+	9-->10
+	9-->11
+	10-->11
 ```


### PR DESCRIPTION
This MR moves to using mermaids node description so that nodes can have spacing and better readability. This will help with long camel case enums.