### PR TITLE
visualiser: Create custom branching name to avoid collision

### DIFF
--- a/testdata/graph-visualisation.md
+++ b/testdata/graph-visualisation.md
@@ -1,6 +1,6 @@
 ```mermaid
 ---
-title: Diagram of example Workflow
+title: Workflow diagram of example
 ---
 stateDiagram-v2
 	direction LR
@@ -9,10 +9,10 @@ stateDiagram-v2
 	10: Middle
 	11: End
 	
-    state if_state <<choice>>
-    9 --> if_state
-    if_state --> 10
-    if_state --> 11 
+    state 9_branching <<choice>>
+    9 --> 9_branching
+    9_branching --> 10
+    9_branching --> 11 
 	
 	10-->11
 ```

--- a/visualiser.go
+++ b/visualiser.go
@@ -120,10 +120,10 @@ stateDiagram-v2
 	{{- end }}
 	{{ range $key, $value := .Transitions }}
 	{{- if gt (len $value.To) 1 }}
-    state if_state <<choice>>
-    {{$value.From}} --> if_state
+    state {{$value.From}}_branching <<choice>>
+    {{$value.From}} --> {{$value.From}}_branching
 	{{- range $index, $to := $value.To }}
-    if_state --> {{$to}}
+    {{$value.From}}_branching --> {{$to}}
 	{{- end}} 
 	{{ else }}
 	{{$value.From}}-->{{index $value.To 0}}


### PR DESCRIPTION
Currently for any branching that takes place the branching name in the `md` file is `if_state` which means that if there is more than one branching in the workflow the visualiser will incorrectly connect the branching due to referencing `if_state`. Instead using the `from` value and adding a suffix of `_branching` allows the output to be `1_branching` which indicates from node `1` branching to node `2` and is represented like such:

```mermaid
---
title: Workflow diagram of example
---
stateDiagram-v2
	direction LR
	
	1: Start
	2: Middle
	3: End
	
    state 1_branching <<choice>>
    1 --> 1_branching
    1_branching --> 2
    1_branching --> 3 

```