### PR TITLE
workflow: Add hooks to builder

### DIFF
--- a/adapters/adaptertest/recordstore.go
+++ b/adapters/adaptertest/recordstore.go
@@ -116,7 +116,7 @@ func testListOutboxEvents(t *testing.T, factory func() workflow.RecordStore) {
 		maker := func(recordID int64) (workflow.OutboxEventData, error) {
 			// Record ID would not have been set if it is a new record. Assign the recordID that the Store provides
 			expected.ID = recordID
-			return workflow.WireRecordToOutboxEventData(*expected, workflow.RunStateInitiated)
+			return workflow.RecordToOutboxEventData(*expected, workflow.RunStateInitiated)
 		}
 
 		err := store.Store(ctx, expected, maker)
@@ -150,7 +150,7 @@ func testDeleteOutboxEvent(t *testing.T, factory func() workflow.RecordStore) {
 		maker := func(recordID int64) (workflow.OutboxEventData, error) {
 			// Run ID would not have been set if it is a new record. Assign the recordID that the Store provides
 			expected.ID = recordID
-			return workflow.WireRecordToOutboxEventData(*expected, workflow.RunStateInitiated)
+			return workflow.RecordToOutboxEventData(*expected, workflow.RunStateInitiated)
 		}
 
 		err := store.Store(ctx, expected, maker)

--- a/await.go
+++ b/await.go
@@ -24,6 +24,12 @@ func (w *Workflow[Type, Status]) Await(ctx context.Context, foreignID, runID str
 
 func awaitWorkflowStatusByForeignID[Type any, Status StatusType](ctx context.Context, w *Workflow[Type, Status], status Status, foreignID, runID string, role string, pollFrequency time.Duration) (*Run[Type, Status], error) {
 	topic := Topic(w.Name, int(status))
+	// Terminal statuses result in the RunState changing to Completed and are stored in the RunStateChangeTopic
+	// as it is a key event in the Workflow Run's lifecycle.
+	if w.statusGraph.IsTerminal(int(status)) {
+		topic = RunStateChangeTopic(w.Name)
+	}
+
 	stream, err := w.eventStreamer.NewConsumer(
 		ctx,
 		topic,
@@ -77,9 +83,11 @@ func awaitWorkflowStatusByForeignID[Type any, Status StatusType](ctx context.Con
 		}
 
 		return &Run[Type, Status]{
-			Record:     *r,
-			Status:     Status(r.Status),
-			Object:     &t,
+			TypedRecord: TypedRecord[Type, Status]{
+				Record: *r,
+				Status: Status(r.Status),
+				Object: &t,
+			},
 			controller: NewRunStateController(w.recordStore.Store, r),
 		}, ack()
 	}

--- a/builder.go
+++ b/builder.go
@@ -199,10 +199,6 @@ func (b *Builder[Type, Status]) OnComplete(hook RunStateChangeHookFunc[Type, Sta
 	b.workflow.runStateChangeHooks[RunStateCompleted] = hook
 }
 
-func (b *Builder[Type, Status]) OnDeleted(hook RunStateChangeHookFunc[Type, Status]) {
-	b.workflow.runStateChangeHooks[RunStateDataDeleted] = hook
-}
-
 func (b *Builder[Type, Status]) Build(eventStreamer EventStreamer, recordStore RecordStore, roleScheduler RoleScheduler, opts ...BuildOption) *Workflow[Type, Status] {
 	b.workflow.eventStreamer = eventStreamer
 	b.workflow.recordStore = recordStore

--- a/builder.go
+++ b/builder.go
@@ -37,6 +37,7 @@ func NewBuilder[Type any, Status StatusType](name string) *Builder[Type, Status]
 				debugMode: false, // Explicit for readability
 				inner:     interal_logger.New(os.Stdout),
 			},
+			runStateChangeHooks: make(map[RunState]RunStateChangeHookFunc[Type, Status]),
 		},
 	}
 }
@@ -184,6 +185,22 @@ func (c *connectorUpdater[Type, Status]) WithOptions(opts ...Option) {
 	c.config.errBackOff = connectorOpts.errBackOff
 	c.config.lag = connectorOpts.lag
 	c.config.lagAlert = connectorOpts.lagAlert
+}
+
+func (b *Builder[Type, Status]) OnPause(hook RunStateChangeHookFunc[Type, Status]) {
+	b.workflow.runStateChangeHooks[RunStatePaused] = hook
+}
+
+func (b *Builder[Type, Status]) OnCancel(hook RunStateChangeHookFunc[Type, Status]) {
+	b.workflow.runStateChangeHooks[RunStateCancelled] = hook
+}
+
+func (b *Builder[Type, Status]) OnComplete(hook RunStateChangeHookFunc[Type, Status]) {
+	b.workflow.runStateChangeHooks[RunStateCompleted] = hook
+}
+
+func (b *Builder[Type, Status]) OnDeleted(hook RunStateChangeHookFunc[Type, Status]) {
+	b.workflow.runStateChangeHooks[RunStateDataDeleted] = hook
 }
 
 func (b *Builder[Type, Status]) Build(eventStreamer EventStreamer, recordStore RecordStore, roleScheduler RoleScheduler, opts ...BuildOption) *Workflow[Type, Status] {

--- a/hook.go
+++ b/hook.go
@@ -1,0 +1,116 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"time"
+
+	"k8s.io/utils/clock"
+
+	"github.com/luno/workflow/internal/metrics"
+)
+
+// RunStateChangeHookFunc defines the function signature for all hooks associated to the run.
+type RunStateChangeHookFunc[Type any, Status StatusType] func(ctx context.Context, record *TypedRecord[Type, Status]) error
+
+func runStateChangeHookConsumer[Type any, Status StatusType](w *Workflow[Type, Status], runState RunState, hook RunStateChangeHookFunc[Type, Status]) {
+	role := makeRole(
+		w.Name,
+		runState.String(),
+		"run-state-change-hook",
+		"consumer",
+	)
+
+	processName := role
+	w.run(role, processName, func(ctx context.Context) error {
+		topic := RunStateChangeTopic(w.Name)
+		consumerStream, err := w.eventStreamer.NewConsumer(
+			ctx,
+			topic,
+			role,
+			WithConsumerPollFrequency(w.defaultOpts.pollingFrequency),
+		)
+		if err != nil {
+			return err
+		}
+		defer consumerStream.Close()
+
+		return RunStateChangeHookForever(ctx, w.Name, processName, consumerStream, runState, w.recordStore.Lookup, hook, w.defaultOpts.lagAlert, w.clock)
+	}, w.defaultOpts.errBackOff)
+}
+
+func RunStateChangeHookForever[Type any, Status StatusType](
+	ctx context.Context,
+	workflowName string,
+	processName string,
+	c Consumer,
+	runState RunState,
+	lookup lookupFunc,
+	hook RunStateChangeHookFunc[Type, Status],
+	lagAlert time.Duration,
+	clock clock.Clock,
+) error {
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		e, ack, err := c.Recv(ctx)
+		if err != nil {
+			return err
+		}
+
+		rs, err := strconv.ParseInt(e.Headers[HeaderRunState], 10, 64)
+		if err != nil {
+			return err
+		}
+
+		if RunState(rs) != runState {
+			metrics.ProcessSkippedEvents.WithLabelValues(workflowName, processName, "mismatch on current run state and target run state").Inc()
+			err = ack()
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		record, err := lookup(ctx, e.ForeignID)
+		if err != nil {
+			if errors.Is(err, ErrRecordNotFound) {
+				metrics.ProcessSkippedEvents.WithLabelValues(workflowName, processName, "record not found").Inc()
+				err = ack()
+				if err != nil {
+					return err
+				}
+
+				continue
+			} else {
+				return err
+			}
+		}
+
+		// Push metrics and alerting around the age of the event being processed.
+		pushLagMetricAndAlerting(workflowName, processName, e.CreatedAt, lagAlert, clock)
+		t2 := clock.Now()
+
+		var t Type
+		err = Unmarshal(record.Object, &t)
+		if err != nil {
+			return err
+		}
+
+		err = hook(ctx, &TypedRecord[Type, Status]{
+			Record: *record,
+			Status: Status(record.Status),
+			Object: &t,
+		})
+		if err != nil {
+			return err
+		}
+
+		metrics.ProcessLatency.WithLabelValues(workflowName, processName).Observe(clock.Since(t2).Seconds())
+		return ack()
+	}
+}

--- a/hook.go
+++ b/hook.go
@@ -3,7 +3,6 @@ package workflow
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -105,7 +104,6 @@ func runHooks[Type any, Status StatusType](
 		var t Type
 		err = Unmarshal(record.Object, &t)
 		if err != nil {
-			fmt.Println(err)
 			metrics.ProcessSkippedEvents.WithLabelValues(workflowName, processName, "unable to unmarshal object").Inc()
 			err = ack()
 			if err != nil {

--- a/hook_internal_test.go
+++ b/hook_internal_test.go
@@ -15,6 +15,29 @@ func Test_runHooks(t *testing.T) {
 	ctx := context.Background()
 	clock := clock.RealClock{}
 
+	t.Run("Return non-nil error from consumer Recv", func(t *testing.T) {
+		testErr := errors.New("test error")
+		err := runHooks[string, testStatus](
+			ctx,
+			"workflow_name",
+			"process_name",
+			consumerImpl{
+				recv: func(ctx context.Context) (*Event, Ack, error) {
+					return nil, nil, testErr
+				},
+				close: func() error {
+					return nil
+				},
+			},
+			RunStateCompleted,
+			nil,
+			nil,
+			time.Minute,
+			clock,
+		)
+		require.Equal(t, testErr, err)
+	})
+
 	t.Run("Skip event on invalid / missing HeaderRunState", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		err := runHooks[string, testStatus](
@@ -41,6 +64,33 @@ func Test_runHooks(t *testing.T) {
 			clock,
 		)
 		require.Equal(t, context.Canceled, err)
+	})
+
+	t.Run("Return ack non-error for on invalid / missing HeaderRunState", func(t *testing.T) {
+		testErr := errors.New("test error")
+		err := runHooks[string, testStatus](
+			ctx,
+			"workflow_name",
+			"process_name",
+			consumerImpl{
+				recv: func(ctx context.Context) (*Event, Ack, error) {
+					return &Event{
+							Headers: map[Header]string{},
+						}, func() error {
+							return testErr
+						}, nil
+				},
+				close: func() error {
+					return nil
+				},
+			},
+			RunStateCompleted,
+			nil,
+			nil,
+			time.Minute,
+			clock,
+		)
+		require.Equal(t, testErr, err)
 	})
 
 	t.Run("Skip event on event RunState and target RunState mismatch", func(t *testing.T) {
@@ -71,6 +121,35 @@ func Test_runHooks(t *testing.T) {
 			clock,
 		)
 		require.Equal(t, context.Canceled, err)
+	})
+
+	t.Run("Return ack non-error for RunState and target RunState mismatch", func(t *testing.T) {
+		testErr := errors.New("test error")
+		err := runHooks[string, testStatus](
+			ctx,
+			"workflow_name",
+			"process_name",
+			consumerImpl{
+				recv: func(ctx context.Context) (*Event, Ack, error) {
+					return &Event{
+							Headers: map[Header]string{
+								HeaderRunState: "1",
+							},
+						}, func() error {
+							return testErr
+						}, nil
+				},
+				close: func() error {
+					return nil
+				},
+			},
+			RunStateCompleted,
+			nil, // Test will panic if the event is not skipped and this function is called.
+			nil,
+			time.Minute,
+			clock,
+		)
+		require.Equal(t, testErr, err)
 	})
 
 	t.Run("Skip event on ErrRecordNotFound", func(t *testing.T) {
@@ -143,6 +222,37 @@ func Test_runHooks(t *testing.T) {
 		require.Equal(t, testErr, err)
 	})
 
+	t.Run("Return non-nil ack error when skipping ErrRecordNotFound from lookup", func(t *testing.T) {
+		testErr := errors.New("test error")
+		err := runHooks[string, testStatus](
+			ctx,
+			"workflow_name",
+			"process_name",
+			consumerImpl{
+				recv: func(ctx context.Context) (*Event, Ack, error) {
+					return &Event{
+							Headers: map[Header]string{
+								HeaderRunState: "5",
+							},
+						}, func() error {
+							return testErr
+						}, nil
+				},
+				close: func() error {
+					return nil
+				},
+			},
+			RunStateCompleted,
+			func(ctx context.Context, id int64) (*Record, error) {
+				return nil, ErrRecordNotFound
+			},
+			nil,
+			time.Minute,
+			clock,
+		)
+		require.Equal(t, testErr, err)
+	})
+
 	t.Run("Skip event on failure to unmarshal object", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		var wg sync.WaitGroup
@@ -179,6 +289,39 @@ func Test_runHooks(t *testing.T) {
 		)
 		wg.Wait()
 		require.Equal(t, context.Canceled, err)
+	})
+
+	t.Run("Return non-nil ack error when skipping for failure to unmarshal object", func(t *testing.T) {
+		testErr := errors.New("test error")
+		err := runHooks[string, testStatus](
+			ctx,
+			"workflow_name",
+			"process_name",
+			consumerImpl{
+				recv: func(ctx context.Context) (*Event, Ack, error) {
+					return &Event{
+							Headers: map[Header]string{
+								HeaderRunState: "5",
+							},
+						}, func() error {
+							return testErr
+						}, nil
+				},
+				close: func() error {
+					return nil
+				},
+			},
+			RunStateCompleted,
+			func(ctx context.Context, id int64) (*Record, error) {
+				return &Record{
+					Object: []byte("INVALID JSON"),
+				}, nil
+			},
+			nil,
+			time.Minute,
+			clock,
+		)
+		require.Equal(t, testErr, err)
 	})
 
 	t.Run("Return non-error if hook errors", func(t *testing.T) {

--- a/hook_internal_test.go
+++ b/hook_internal_test.go
@@ -1,0 +1,233 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/clock"
+)
+
+func Test_runHooks(t *testing.T) {
+	ctx := context.Background()
+	clock := clock.RealClock{}
+
+	t.Run("Skip event on invalid / missing HeaderRunState", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		err := runHooks[string, testStatus](
+			ctx,
+			"workflow_name",
+			"process_name",
+			consumerImpl{
+				recv: func(ctx context.Context) (*Event, Ack, error) {
+					return &Event{
+							Headers: map[Header]string{},
+						}, func() error {
+							cancel()
+							return nil
+						}, nil
+				},
+				close: func() error {
+					return nil
+				},
+			},
+			RunStateCompleted,
+			nil,
+			nil,
+			time.Minute,
+			clock,
+		)
+		require.Equal(t, context.Canceled, err)
+	})
+
+	t.Run("Skip event on event RunState and target RunState mismatch", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		err := runHooks[string, testStatus](
+			ctx,
+			"workflow_name",
+			"process_name",
+			consumerImpl{
+				recv: func(ctx context.Context) (*Event, Ack, error) {
+					return &Event{
+							Headers: map[Header]string{
+								HeaderRunState: "1",
+							},
+						}, func() error {
+							cancel()
+							return nil
+						}, nil
+				},
+				close: func() error {
+					return nil
+				},
+			},
+			RunStateCompleted,
+			nil, // Test will panic if the event is not skipped and this function is called.
+			nil,
+			time.Minute,
+			clock,
+		)
+		require.Equal(t, context.Canceled, err)
+	})
+
+	t.Run("Skip event on ErrRecordNotFound", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		err := runHooks[string, testStatus](
+			ctx,
+			"workflow_name",
+			"process_name",
+			consumerImpl{
+				recv: func(ctx context.Context) (*Event, Ack, error) {
+					return &Event{
+							Headers: map[Header]string{
+								HeaderRunState: "5",
+							},
+						}, func() error {
+							cancel()
+							return nil
+						}, nil
+				},
+				close: func() error {
+					return nil
+				},
+			},
+			RunStateCompleted,
+			func(ctx context.Context, id int64) (*Record, error) {
+				// Ensures that the test only finished if this is called
+				wg.Done()
+				return nil, ErrRecordNotFound
+			},
+			nil,
+			time.Minute,
+			clock,
+		)
+		wg.Wait()
+		require.Equal(t, context.Canceled, err)
+	})
+
+	t.Run("Return non-nil error from lookup", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		testErr := errors.New("test error")
+		err := runHooks[string, testStatus](
+			ctx,
+			"workflow_name",
+			"process_name",
+			consumerImpl{
+				recv: func(ctx context.Context) (*Event, Ack, error) {
+					return &Event{
+							Headers: map[Header]string{
+								HeaderRunState: "5",
+							},
+						}, func() error {
+							cancel()
+							return nil
+						}, nil
+				},
+				close: func() error {
+					return nil
+				},
+			},
+			RunStateCompleted,
+			func(ctx context.Context, id int64) (*Record, error) {
+				return nil, testErr
+			},
+			nil,
+			time.Minute,
+			clock,
+		)
+		require.Equal(t, testErr, err)
+	})
+
+	t.Run("Skip event on failure to unmarshal object", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		err := runHooks[string, testStatus](
+			ctx,
+			"workflow_name",
+			"process_name",
+			consumerImpl{
+				recv: func(ctx context.Context) (*Event, Ack, error) {
+					return &Event{
+							Headers: map[Header]string{
+								HeaderRunState: "5",
+							},
+						}, func() error {
+							cancel()
+							return nil
+						}, nil
+				},
+				close: func() error {
+					return nil
+				},
+			},
+			RunStateCompleted,
+			func(ctx context.Context, id int64) (*Record, error) {
+				wg.Done()
+				return &Record{
+					Object: []byte("INVALID JSON"),
+				}, nil
+			},
+			nil,
+			time.Minute,
+			clock,
+		)
+		wg.Wait()
+		require.Equal(t, context.Canceled, err)
+	})
+
+	t.Run("Return non-error if hook errors", func(t *testing.T) {
+		testErr := errors.New("test error")
+		err := runHooks[string, testStatus](
+			ctx,
+			"workflow_name",
+			"process_name",
+			consumerImpl{
+				recv: func(ctx context.Context) (*Event, Ack, error) {
+					return &Event{
+							Headers: map[Header]string{
+								HeaderRunState: "5",
+							},
+						}, func() error {
+							return nil
+						}, nil
+				},
+				close: func() error {
+					return nil
+				},
+			},
+			RunStateCompleted,
+			func(ctx context.Context, id int64) (*Record, error) {
+				return &Record{
+					Object: []byte(`"VALID JSON"`),
+				}, nil
+			},
+			func(ctx context.Context, record *TypedRecord[string, testStatus]) error {
+				return testErr
+			},
+			time.Minute,
+			clock,
+		)
+		require.Equal(t, testErr, err)
+	})
+}
+
+type consumerImpl struct {
+	recv  func(ctx context.Context) (*Event, Ack, error)
+	close func() error
+}
+
+func (c consumerImpl) Recv(ctx context.Context) (*Event, Ack, error) {
+	return c.recv(ctx)
+}
+
+func (c consumerImpl) Close() error {
+	return c.close()
+}
+
+var _ Consumer = (*consumerImpl)(nil)

--- a/hook_test.go
+++ b/hook_test.go
@@ -1,0 +1,101 @@
+package workflow_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/luno/workflow"
+	"github.com/luno/workflow/adapters/memrecordstore"
+	"github.com/luno/workflow/adapters/memrolescheduler"
+	"github.com/luno/workflow/adapters/memstreamer"
+)
+
+func TestWorkflow_OnPauseHook(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	wf := setupHookTest(t, func(b *workflow.Builder[MyType, status]) {
+		b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[MyType, status]) (status, error) {
+			return r.Pause(ctx)
+		}, StatusMiddle)
+
+		b.OnPause(func(ctx context.Context, record *workflow.TypedRecord[MyType, status]) error {
+			wg.Done()
+			return nil
+		})
+	})
+
+	foreignID := "andrew"
+	_, err := wf.Trigger(context.Background(), foreignID, StatusStart)
+	require.Nil(t, err)
+
+	wg.Wait()
+}
+
+func TestWorkflow_OnCancelHook(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	wf := setupHookTest(t, func(b *workflow.Builder[MyType, status]) {
+		b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[MyType, status]) (status, error) {
+			return r.Cancel(ctx)
+		}, StatusMiddle)
+
+		b.OnCancel(func(ctx context.Context, record *workflow.TypedRecord[MyType, status]) error {
+			wg.Done()
+			return nil
+		})
+	})
+
+	foreignID := "andrew"
+	_, err := wf.Trigger(context.Background(), foreignID, StatusStart)
+	require.Nil(t, err)
+
+	wg.Wait()
+}
+
+func TestWorkflow_OnCompleteHook(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	wf := setupHookTest(t, func(b *workflow.Builder[MyType, status]) {
+		b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[MyType, status]) (status, error) {
+			return StatusEnd, nil
+		}, StatusEnd)
+
+		b.OnComplete(func(ctx context.Context, record *workflow.TypedRecord[MyType, status]) error {
+			wg.Done()
+			return nil
+		})
+	})
+
+	foreignID := "andrew"
+	_, err := wf.Trigger(context.Background(), foreignID, StatusStart)
+	require.Nil(t, err)
+
+	wg.Wait()
+}
+
+func setupHookTest(t *testing.T, custom func(b *workflow.Builder[MyType, status])) *workflow.Workflow[MyType, status] {
+	b := workflow.NewBuilder[MyType, status]("hooks")
+
+	custom(b)
+
+	wf := b.Build(
+		memstreamer.New(),
+		memrecordstore.New(),
+		memrolescheduler.New(),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+	})
+
+	wf.Run(ctx)
+	t.Cleanup(wf.Stop)
+
+	return wf
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -409,7 +409,7 @@ func update(ctx context.Context, store workflow.RecordStore, wr *workflow.Record
 	return store.Store(ctx, wr, func(recordID int64) (workflow.OutboxEventData, error) {
 		// Run ID would not have been set if it is a new record. Assign the recordID that the Store provides
 		wr.ID = recordID
-		return workflow.WireRecordToOutboxEventData(*wr, workflow.RunStateUnknown)
+		return workflow.RecordToOutboxEventData(*wr, workflow.RunStateUnknown)
 	})
 }
 

--- a/record.go
+++ b/record.go
@@ -2,6 +2,8 @@ package workflow
 
 import "time"
 
+// Record is the cornerstone of Workflow. Record must always be wire compatible with no generics as it's intended
+// purpose is to be the
 type Record struct {
 	ID           int64
 	WorkflowName string
@@ -12,4 +14,11 @@ type Record struct {
 	Object       []byte
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
+}
+
+// TypedRecord differs from Record in that it contains a Typed Object and Typed Status
+type TypedRecord[Type any, Status StatusType] struct {
+	Record
+	Status Status
+	Object *Type
 }

--- a/runstate.go
+++ b/runstate.go
@@ -120,7 +120,7 @@ func (rsc *runStateControllerImpl) DeleteData(ctx context.Context) error {
 func (rsc *runStateControllerImpl) update(ctx context.Context, rs RunState) error {
 	valid, ok := runStateTransitions[rsc.record.RunState]
 	if !ok || !valid[rs] {
-		return fmt.Errorf("invalid RunState: %s", rsc.record.RunState)
+		return fmt.Errorf("invalid RunState: from %s | to %s", rsc.record.RunState, rs)
 	}
 
 	previousRunState := rsc.record.RunState

--- a/runstate_internal_test.go
+++ b/runstate_internal_test.go
@@ -23,3 +23,318 @@ func TestNoopRunStateController(t *testing.T) {
 	err = ctrl.DeleteData(ctx)
 	require.Nil(t, err)
 }
+
+func TestRunStateControllerTransitions(t *testing.T) {
+	testCases := []struct {
+		name  string
+		from  RunState
+		to    RunState
+		valid bool
+	}{
+		{
+			name:  "Initiated to Running [valid]",
+			from:  RunStateInitiated,
+			to:    RunStateRunning,
+			valid: true,
+		},
+		{
+			name:  "Initiated to Paused [valid]",
+			from:  RunStateInitiated,
+			to:    RunStatePaused,
+			valid: true,
+		},
+		{
+			name:  "Initiated to Initiated [invalid]",
+			from:  RunStateInitiated,
+			to:    RunStateInitiated,
+			valid: false,
+		},
+		{
+			name:  "Initiated to Cancelled [invalid]",
+			from:  RunStateInitiated,
+			to:    RunStateCancelled,
+			valid: false,
+		},
+		{
+			name:  "Initiated to Completed [invalid]",
+			from:  RunStateInitiated,
+			to:    RunStateCompleted,
+			valid: false,
+		},
+		{
+			name:  "Initiated to DataDeleted [invalid]",
+			from:  RunStateInitiated,
+			to:    RunStateDataDeleted,
+			valid: false,
+		},
+		{
+			name:  "Initiated to RequestedDataDeleted [invalid]",
+			from:  RunStateInitiated,
+			to:    RunStateRequestedDataDeleted,
+			valid: false,
+		},
+		{
+			name:  "Running to Initiated [invalid]",
+			from:  RunStateRunning,
+			to:    RunStateInitiated,
+			valid: false,
+		},
+		{
+			name:  "Running to Running [invalid]",
+			from:  RunStateRunning,
+			to:    RunStateRunning,
+			valid: false,
+		},
+		{
+			name:  "Running to Completed [valid]",
+			from:  RunStateRunning,
+			to:    RunStateCompleted,
+			valid: true,
+		},
+		{
+			name:  "Running to Paused [valid]",
+			from:  RunStateRunning,
+			to:    RunStatePaused,
+			valid: true,
+		},
+		{
+			name:  "Running to Cancelled [valid]",
+			from:  RunStateRunning,
+			to:    RunStateCancelled,
+			valid: true,
+		},
+		{
+			name:  "Running to RequestedDataDeleted [invalid]",
+			from:  RunStateRunning,
+			to:    RunStateRequestedDataDeleted,
+			valid: false,
+		},
+		{
+			name:  "Running to DataDeleted [invalid]",
+			from:  RunStateRunning,
+			to:    RunStateDataDeleted,
+			valid: false,
+		},
+		{
+			name:  "Paused to Initiated [invalid]",
+			from:  RunStatePaused,
+			to:    RunStateInitiated,
+			valid: false,
+		},
+		{
+			name:  "Paused to Paused [invalid]",
+			from:  RunStatePaused,
+			to:    RunStatePaused,
+			valid: false,
+		},
+		{
+			name:  "Paused to Running [valid]",
+			from:  RunStatePaused,
+			to:    RunStateRunning,
+			valid: true,
+		},
+		{
+			name:  "Paused to Cancelled [valid]",
+			from:  RunStatePaused,
+			to:    RunStateCancelled,
+			valid: true,
+		},
+		{
+			name:  "Paused to Completed [invalid]",
+			from:  RunStatePaused,
+			to:    RunStateCompleted,
+			valid: false,
+		},
+		{
+			name:  "Paused to RequestedDataDeleted [invalid]",
+			from:  RunStatePaused,
+			to:    RunStateRequestedDataDeleted,
+			valid: false,
+		},
+		{
+			name:  "Paused to DataDeleted [invalid]",
+			from:  RunStatePaused,
+			to:    RunStateDataDeleted,
+			valid: false,
+		},
+		{
+			name:  "Completed to RequestedDataDeleted [valid]",
+			from:  RunStateCompleted,
+			to:    RunStateRequestedDataDeleted,
+			valid: true,
+		},
+		{
+			name:  "Completed to DataDeleted [invalid]",
+			from:  RunStateCompleted,
+			to:    RunStateDataDeleted,
+			valid: false,
+		},
+		{
+			name:  "Completed to Initiated [invalid]",
+			from:  RunStateCompleted,
+			to:    RunStateInitiated,
+			valid: false,
+		},
+		{
+			name:  "Completed to Running [invalid]",
+			from:  RunStateCompleted,
+			to:    RunStateRunning,
+			valid: false,
+		},
+		{
+			name:  "Completed to Paused [invalid]",
+			from:  RunStateCompleted,
+			to:    RunStatePaused,
+			valid: false,
+		},
+		{
+			name:  "Completed to Completed [invalid]",
+			from:  RunStateCompleted,
+			to:    RunStateCompleted,
+			valid: false,
+		},
+		{
+			name:  "Completed to Cancelled [invalid]",
+			from:  RunStateCompleted,
+			to:    RunStateCancelled,
+			valid: false,
+		},
+		{
+			name:  "Cancelled to RequestedDataDeleted [valid]",
+			from:  RunStateCancelled,
+			to:    RunStateRequestedDataDeleted,
+			valid: true,
+		},
+		{
+			name:  "Cancelled to DataDeleted [invalid]",
+			from:  RunStateCancelled,
+			to:    RunStateDataDeleted,
+			valid: false,
+		},
+		{
+			name:  "Cancelled to Initiated [invalid]",
+			from:  RunStateCancelled,
+			to:    RunStateInitiated,
+			valid: false,
+		},
+		{
+			name:  "Cancelled to Running [invalid]",
+			from:  RunStateCancelled,
+			to:    RunStateRunning,
+			valid: false,
+		},
+		{
+			name:  "Cancelled to Paused [invalid]",
+			from:  RunStateCancelled,
+			to:    RunStatePaused,
+			valid: false,
+		},
+		{
+			name:  "Cancelled to Completed [invalid]",
+			from:  RunStateCancelled,
+			to:    RunStateCompleted,
+			valid: false,
+		},
+		{
+			name:  "Cancelled to Cancelled [invalid]",
+			from:  RunStateCancelled,
+			to:    RunStateCancelled,
+			valid: false,
+		},
+		{
+			name:  "RequestedDataDeleted to DataDeleted [valid]",
+			from:  RunStateRequestedDataDeleted,
+			to:    RunStateDataDeleted,
+			valid: true,
+		},
+		{
+			name:  "RequestedDataDeleted to Initiated [invalid]",
+			from:  RunStateRequestedDataDeleted,
+			to:    RunStateInitiated,
+			valid: false,
+		},
+		{
+			name:  "RequestedDataDeleted to Running [invalid]",
+			from:  RunStateRequestedDataDeleted,
+			to:    RunStateRunning,
+			valid: false,
+		},
+		{
+			name:  "RequestedDataDeleted to Paused [invalid]",
+			from:  RunStateRequestedDataDeleted,
+			to:    RunStatePaused,
+			valid: false,
+		},
+		{
+			name:  "RequestedDataDeleted to Completed [invalid]",
+			from:  RunStateRequestedDataDeleted,
+			to:    RunStateCompleted,
+			valid: false,
+		},
+		{
+			name:  "RequestedDataDeleted to Cancelled [invalid]",
+			from:  RunStateRequestedDataDeleted,
+			to:    RunStateCancelled,
+			valid: false,
+		},
+		{
+			name:  "RequestedDataDeleted to RequestedDataDeleted [invalid]",
+			from:  RunStateRequestedDataDeleted,
+			to:    RunStateRequestedDataDeleted,
+			valid: false,
+		},
+		{
+			name:  "DataDeleted to RequestedDataDeleted [valid]",
+			from:  RunStateDataDeleted,
+			to:    RunStateRequestedDataDeleted,
+			valid: true,
+		},
+		{
+			name:  "DataDeleted to Initiated [invalid]",
+			from:  RunStateDataDeleted,
+			to:    RunStateInitiated,
+			valid: false,
+		},
+		{
+			name:  "DataDeleted to Running [invalid]",
+			from:  RunStateDataDeleted,
+			to:    RunStateRunning,
+			valid: false,
+		},
+		{
+			name:  "DataDeleted to Paused [invalid]",
+			from:  RunStateDataDeleted,
+			to:    RunStatePaused,
+			valid: false,
+		},
+		{
+			name:  "DataDeleted to Completed [invalid]",
+			from:  RunStateDataDeleted,
+			to:    RunStateCompleted,
+			valid: false,
+		},
+		{
+			name:  "DataDeleted to Cancelled [invalid]",
+			from:  RunStateDataDeleted,
+			to:    RunStateCancelled,
+			valid: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := runStateControllerImpl{
+				record: &Record{
+					RunState: tc.from,
+				},
+				store: func(ctx context.Context, record *Record, maker OutboxEventDataMaker) error {
+					return nil
+				},
+			}
+
+			ctx := context.Background()
+			err := ctrl.update(ctx, tc.to)
+			require.Equal(t, tc.valid, err == nil)
+		})
+	}
+}

--- a/runstate_test.go
+++ b/runstate_test.go
@@ -258,3 +258,7 @@ func TestRunStateStopped(t *testing.T) {
 		require.Equal(t, expected, state.Stopped())
 	}
 }
+
+func TestRunStateOutOfBoundsString(t *testing.T) {
+	require.Equal(t, "RunState(999)", workflow.RunState(999).String())
+}

--- a/testing.go
+++ b/testing.go
@@ -133,9 +133,11 @@ func NewTestingRun[Type any, Status StatusType](t *testing.T, wr Record, object 
 	}
 
 	return Run[Type, Status]{
-		Record:     wr,
-		Status:     Status(wr.Status),
-		Object:     &object,
+		TypedRecord: TypedRecord[Type, Status]{
+			Record: wr,
+			Status: Status(wr.Status),
+			Object: &object,
+		},
 		controller: &options.controller,
 	}
 }

--- a/topic.go
+++ b/topic.go
@@ -25,3 +25,11 @@ func DeleteTopic(workflowName string) string {
 		"delete",
 	}, topicSeparator)
 }
+
+func RunStateChangeTopic(workflowName string) string {
+	name := strings.ReplaceAll(workflowName, " ", emptySpaceReplacement)
+	return strings.Join([]string{
+		name,
+		"run-state-change",
+	}, topicSeparator)
+}

--- a/update.go
+++ b/update.go
@@ -64,7 +64,7 @@ func newUpdater[Type any, Status StatusType](lookup lookupFunc, store storeFunc,
 		return store(ctx, updatedRecord, func(recordID int64) (OutboxEventData, error) {
 			// Run ID would not have been set if it is a new record. Assign the recordID that the Store provides
 			updatedRecord.ID = recordID
-			return WireRecordToOutboxEventData(*updatedRecord, record.RunState)
+			return RecordToOutboxEventData(*updatedRecord, record.RunState)
 		})
 	}
 }
@@ -100,6 +100,6 @@ func updateWireRecord(ctx context.Context, store storeFunc, record *Record, prev
 	return store(ctx, record, func(recordID int64) (OutboxEventData, error) {
 		// Run ID would not have been set if it is a new record. Assign the recordID that the Store provides
 		record.ID = recordID
-		return WireRecordToOutboxEventData(*record, previousRunState)
+		return RecordToOutboxEventData(*record, previousRunState)
 	})
 }

--- a/update_internal_test.go
+++ b/update_internal_test.go
@@ -33,11 +33,13 @@ func TestUpdater(t *testing.T) {
 			},
 			current: statusStart,
 			update: Run[string, testStatus]{
-				Record: Record{
-					RunState: RunStateRunning,
-					Status:   int(statusMiddle),
+				TypedRecord: TypedRecord[string, testStatus]{
+					Record: Record{
+						RunState: RunStateRunning,
+						Status:   int(statusMiddle),
+					},
+					Status: statusMiddle,
 				},
-				Status: statusMiddle,
 			},
 			transitions: []graph.Transition{
 				{
@@ -60,11 +62,13 @@ func TestUpdater(t *testing.T) {
 			},
 			current: statusStart,
 			update: Run[string, testStatus]{
-				Record: Record{
-					RunState: RunStateRunning,
-					Status:   int(statusMiddle),
+				TypedRecord: TypedRecord[string, testStatus]{
+					Record: Record{
+						RunState: RunStateRunning,
+						Status:   int(statusMiddle),
+					},
+					Status: statusMiddle,
 				},
-				Status: statusMiddle,
 			},
 			transitions: []graph.Transition{},
 			expectedErr: fmt.Errorf("current status not defined in graph: current=%s", statusStart),
@@ -78,11 +82,13 @@ func TestUpdater(t *testing.T) {
 			},
 			current: statusStart,
 			update: Run[string, testStatus]{
-				Record: Record{
-					RunState: RunStateRunning,
-					Status:   int(statusMiddle),
+				TypedRecord: TypedRecord[string, testStatus]{
+					Record: Record{
+						RunState: RunStateRunning,
+						Status:   int(statusMiddle),
+					},
+					Status: statusMiddle,
 				},
-				Status: statusMiddle,
 			},
 			transitions: []graph.Transition{
 				{
@@ -118,11 +124,13 @@ func TestUpdater(t *testing.T) {
 			},
 			current: statusStart,
 			update: Run[string, testStatus]{
-				Record: Record{
-					RunState: RunStateRunning,
-					Status:   int(statusMiddle),
+				TypedRecord: TypedRecord[string, testStatus]{
+					Record: Record{
+						RunState: RunStateRunning,
+						Status:   int(statusMiddle),
+					},
+					Status: statusMiddle,
 				},
-				Status: statusMiddle,
 			},
 			transitions: []graph.Transition{
 				{


### PR DESCRIPTION
This MR / PR focuses on adding the ability to write a short hand consumer for RunState changes. This was always possible before but would require the user to use the correct topic setup or if using Reflex using a StreamFunc to stream and filter by RunState. These are simpler and more discoverable being part of the builder and does not extend the feature set but rather enhances the discoverability of what already exists.