### PR TITLE
workflow: Add process name to error logs

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -215,7 +215,7 @@ func runOnce(
 		// Exit cleanly if error returned is cancellation of context
 		return err
 	} else if err != nil {
-		logger.Error(ctx, fmt.Errorf("run error [role=%v], [process=%v]: %v", role, processName, err))
+		logger.Error(ctx, fmt.Errorf("run error [role=%s], [process=%s]: %v", role, processName, err))
 
 		// Return nil to try again
 		return nil
@@ -230,7 +230,7 @@ func runOnce(
 		// and if the parent context was cancelled then that will exit safely.
 		return nil
 	} else if err != nil {
-		logger.Error(ctx, fmt.Errorf("run error [role=%v], [process=%v]: %v", role, processName, err))
+		logger.Error(ctx, fmt.Errorf("run error [role=%s], [process=%s]: %v", role, processName, err))
 		metrics.ProcessErrors.WithLabelValues(workflowName, processName).Inc()
 
 		timer := clock.NewTimer(errBackOff)

--- a/workflow.go
+++ b/workflow.go
@@ -215,7 +215,7 @@ func runOnce(
 		// Exit cleanly if error returned is cancellation of context
 		return err
 	} else if err != nil {
-		logger.Error(ctx, fmt.Errorf("run error [role=%v]: %v", role, err))
+		logger.Error(ctx, fmt.Errorf("run error [role=%v], [process=%v]: %v", role, processName, err))
 
 		// Return nil to try again
 		return nil
@@ -230,7 +230,7 @@ func runOnce(
 		// and if the parent context was cancelled then that will exit safely.
 		return nil
 	} else if err != nil {
-		logger.Error(ctx, fmt.Errorf("run error [role=%v]: %v", role, err))
+		logger.Error(ctx, fmt.Errorf("run error [role=%v], [process=%v]: %v", role, processName, err))
 		metrics.ProcessErrors.WithLabelValues(workflowName, processName).Inc()
 
 		timer := clock.NewTimer(errBackOff)

--- a/workflow_internal_test.go
+++ b/workflow_internal_test.go
@@ -78,7 +78,7 @@ func Test_runOnce(t *testing.T) {
 			time.Minute,
 		)
 		require.Nil(t, err)
-		require.Contains(t, buf.String(), `"msg":"run error [role=role-1]: test error"`)
+		require.Contains(t, buf.String(), `"msg":"run error [role=role-1], [process=process-1]: test error"`)
 	})
 
 	t.Run("Cancelled parent context during process execution retries and exits with context.Canceled ", func(t *testing.T) {
@@ -149,7 +149,7 @@ func Test_runOnce(t *testing.T) {
 		)
 
 		require.Nil(t, err)
-		require.Contains(t, buf.String(), `"msg":"run error [role=role-1]: test error`)
+		require.Contains(t, buf.String(), `"msg":"run error [role=role-1], [process=process-1]: test error`)
 	})
 
 	t.Run("Updates process state", func(t *testing.T) {


### PR DESCRIPTION
Adding a human readable 'process' name to error log to link the process in the logs to the metrics and some alerts.