### PR TITLE
testing: Add helper function to wait for a record to enter a certain …

### DIFF
--- a/store.go
+++ b/store.go
@@ -33,8 +33,6 @@ type TestingRecordStore interface {
 	RecordStore
 
 	Snapshots(workflowName, foreignID, runID string) []*Record
-	SetSnapshotOffset(workflowName, foreignID, runID string, offset int)
-	SnapshotOffset(workflowName, foreignID, runID string) int
 }
 
 // OutboxEventDataMaker is a function that constructs the expected structure of an outbox event used for creating an

--- a/testing.go
+++ b/testing.go
@@ -11,26 +11,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TriggerCallbackOn[Type any, Status StatusType, Payload any](t testing.TB, w *Workflow[Type, Status], foreignID, runID string, waitFor Status, p Payload) {
+func TriggerCallbackOn[Type any, Status StatusType, Payload any](t testing.TB, w *Workflow[Type, Status], foreignID, runID string, waitForStatus Status, p Payload) {
 	if t == nil {
 		panic("TriggerCallbackOn can only be used for testing")
 	}
 
-	ctx := context.TODO()
-
-	_, err := w.Await(ctx, foreignID, runID, waitFor)
-	require.Nil(t, err)
+	_ = waitFor(t, w, foreignID, func(r *Record) (bool, error) {
+		return r.Status == int(waitForStatus), nil
+	})
 
 	b, err := json.Marshal(p)
 	require.Nil(t, err)
 
-	err = w.Callback(ctx, foreignID, waitFor, bytes.NewReader(b))
+	err = w.Callback(w.ctx, foreignID, waitForStatus, bytes.NewReader(b))
 	require.Nil(t, err)
 }
 
 func AwaitTimeoutInsert[Type any, Status StatusType](t testing.TB, w *Workflow[Type, Status], foreignID, runID string, waitFor Status) {
 	if t == nil {
-		panic("AwaitTimeout can only be used for testing")
+		panic("AwaitTimeoutInsert can only be used for testing")
 	}
 
 	var found bool
@@ -61,49 +60,19 @@ func AwaitTimeoutInsert[Type any, Status StatusType](t testing.TB, w *Workflow[T
 	}
 }
 
-func Require[Type any, Status StatusType](t testing.TB, w *Workflow[Type, Status], foreignID string, waitFor Status, expected Type) {
+func Require[Type any, Status StatusType](t testing.TB, w *Workflow[Type, Status], foreignID string, waitForStatus Status, expected Type) {
 	if t == nil {
 		panic("Require can only be used for testing")
 	}
 
-	if !w.statusGraph.IsValid(int(waitFor)) {
-		t.Error(fmt.Sprintf(`Status provided is not configured for workflow: "%v" (Workflow: %v)`, waitFor, w.Name))
+	if !w.statusGraph.IsValid(int(waitForStatus)) {
+		t.Error(fmt.Sprintf(`Status provided is not configured for workflow: "%v" (Workflow: %v)`, waitForStatus, w.Name))
 		return
 	}
 
-	testingStore, ok := w.recordStore.(TestingRecordStore)
-	if !ok {
-		panic("Require function requires TestingRecordStore implementation for record store dependency")
-	}
-
-	var runID string
-	for runID == "" {
-		latest, err := w.recordStore.Latest(context.Background(), w.Name, foreignID)
-		if errors.Is(err, ErrRecordNotFound) {
-			continue
-		} else {
-			require.Nil(t, err)
-		}
-
-		runID = latest.RunID
-	}
-
-	var wr *Record
-	for wr == nil {
-		offset := testingStore.SnapshotOffset(w.Name, foreignID, runID)
-		snapshots := testingStore.Snapshots(w.Name, foreignID, runID)
-		for i, r := range snapshots {
-			if offset > i {
-				continue
-			}
-
-			if r.Status == int(waitFor) {
-				wr = r
-			}
-
-			testingStore.SetSnapshotOffset(w.Name, foreignID, runID, offset+1)
-		}
-	}
+	wr := waitFor(t, w, foreignID, func(r *Record) (bool, error) {
+		return r.Status == int(waitForStatus), nil
+	})
 
 	var actual Type
 	err := Unmarshal(wr.Object, &actual)
@@ -134,28 +103,49 @@ func WaitFor[Type any, Status StatusType](
 		panic("WaitFor can only be used for testing")
 	}
 
-	var found bool
-	for !found {
-		if w.ctx.Err() != nil {
-			return
-		}
-
-		latest, err := w.recordStore.Latest(w.ctx, w.Name, foreignID)
+	waitFor(t, w, foreignID, func(r *Record) (bool, error) {
+		run, err := buildRun[Type, Status](w.recordStore.Store, r)
 		require.Nil(t, err)
 
-		run, err := buildRun[Type, Status](w.recordStore.Store, latest)
-		require.Nil(t, err)
+		return fn(run)
+	})
+}
 
-		ok, err := fn(run)
-		require.Nil(t, err)
-
-		if !ok {
-			continue
-		}
-
-		found = true
-		break
+func waitFor[Type any, Status StatusType](t testing.TB, w *Workflow[Type, Status], foreignID string, fn func(r *Record) (bool, error)) *Record {
+	testingStore, ok := w.recordStore.(TestingRecordStore)
+	if !ok {
+		panic("TestingRecordStore implementation for record store dependency required")
 	}
+
+	var runID string
+	for runID == "" {
+		latest, err := w.recordStore.Latest(context.Background(), w.Name, foreignID)
+		if errors.Is(err, ErrRecordNotFound) {
+			continue
+		} else {
+			require.Nil(t, err)
+		}
+
+		runID = latest.RunID
+	}
+
+	// Reset the offset run through all the changes and not just from the offset
+	// testingStore.SetSnapshotOffset(w.Name, foreignID, runID, 0)
+
+	var wr *Record
+	for wr == nil {
+		snapshots := testingStore.Snapshots(w.Name, foreignID, runID)
+		for _, r := range snapshots {
+			ok, err := fn(r)
+			require.Nil(t, err)
+
+			if ok {
+				wr = r
+			}
+		}
+	}
+
+	return wr
 }
 
 // NewTestingRun should be used when testing logic that defines a workflow.Run as a parameter. This is usually the

--- a/testing_test.go
+++ b/testing_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -38,6 +39,35 @@ func TestRequire(t *testing.T) {
 	workflow.Require(t, wf, fid, StatusEnd, "Lower")
 }
 
+func TestRequire_validation(t *testing.T) {
+	t.Run("Require must be provided with testing and will panic without", func(t *testing.T) {
+		require.PanicsWithValue(t,
+			"Require can only be used for testing",
+			func() {
+				workflow.Require[string, status](nil, nil, "", StatusEnd, "")
+			}, "Not providing a testing.T or testing.B should panic")
+	})
+
+	t.Run("Require must be provided with a workflow that is using a record store that implements TestingRecordStore", func(t *testing.T) {
+		require.PanicsWithValue(t,
+			"Require function requires TestingRecordStore implementation for record store dependency",
+			func() {
+				b := workflow.NewBuilder[string, status]("test")
+				b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[string, status]) (status, error) {
+					return r.Cancel(ctx)
+				}, StatusEnd)
+
+				wf := b.Build(
+					memstreamer.New(),
+					nil,
+					memrolescheduler.New(),
+				)
+
+				workflow.Require(t, wf, "", StatusEnd, "")
+			}, "Not providing a workflow using a TestingRecordStore implemented record store should panic")
+	})
+}
+
 // testCustomMarshaler is for testing and implements custom and weird behaviour via the
 // MarshalJSON method and this is to test that the Require function can successfully compare
 // the actual and expected by running them through the same encoding / decoding process.
@@ -45,4 +75,38 @@ type testCustomMarshaler string
 
 func (t testCustomMarshaler) MarshalJSON() ([]byte, error) {
 	return json.Marshal(strings.ToLower(string(t)))
+}
+
+func TestWaitFor_validation(t *testing.T) {
+	require.PanicsWithValue(t,
+		"WaitFor can only be used for testing",
+		func() {
+			workflow.WaitFor[string, status](nil, nil, "", nil)
+		}, "Not providing a testing.T or testing.B should panic")
+}
+
+func TestWaitFor(t *testing.T) {
+	b := workflow.NewBuilder[string, status]("test")
+	b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[string, status]) (status, error) {
+		return r.Cancel(ctx)
+	}, StatusEnd)
+
+	wf := b.Build(
+		memstreamer.New(),
+		memrecordstore.New(),
+		memrolescheduler.New(),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	t.Cleanup(cancel)
+	wf.Run(ctx)
+	t.Cleanup(wf.Stop)
+
+	fid := "10298309123"
+	_, err := wf.Trigger(ctx, fid, StatusStart)
+	require.Nil(t, err)
+
+	workflow.WaitFor(t, wf, fid, func(r *workflow.Run[string, status]) (bool, error) {
+		return r.RunState == workflow.RunStateCompleted, nil
+	})
 }


### PR DESCRIPTION
This PR adds a testing helper function where you can wait for a specific state of the workflow run. Instead of adding lots of helpers I went with a single function approach where the user can define the condition in their own function and provide that as an option.

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests, if appropriate.

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Did you install pre-commit hooks before committing?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?

