### PR TITLE
webui: Add simplified trigger date and add processing duration

### DIFF
--- a/adapters/webui/internal/frontend/home.html
+++ b/adapters/webui/internal/frontend/home.html
@@ -87,13 +87,13 @@
             <table class="min-w-full bg-white dark:bg-gray-900 rounded-lg shadow-sm">
                 <thead class="bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-b border-gray-200 dark:border-gray-600">
                 <tr>
+                    <th class="py-3 px-4 text-center font-medium text-sm">Triggered At</th>
                     <th class="py-3 px-4 text-center font-medium text-sm">Workflow</th>
                     <th class="py-3 px-4 text-center font-medium text-sm">Foreign ID</th>
                     <th class="py-3 px-4 text-center font-medium text-sm">Run ID</th>
                     <th class="py-3 px-4 text-center font-medium text-sm">Run State</th>
                     <th class="py-3 px-4 text-center font-medium text-sm">Status</th>
-                    <th class="py-3 px-4 text-center font-medium text-sm">Created At</th>
-                    <th class="py-3 px-4 text-center font-medium text-sm">Updated At</th>
+                    <th class="py-3 px-4 text-center font-medium text-sm">Duration</th>
                     <th class="py-3 px-4 text-center font-medium text-sm">Object</th>
                     <th class="py-3 px-4 text-center font-medium text-sm">Actions</th>
                 </tr>


### PR DESCRIPTION
This MR introduces some UI changes to show the TriggeredAt column first in a simple manner. If the tiggered at is on the current day it only shows time  and if its on a different day but same month then shows the day and not the month and so forth.

This MR also introduces a Duration column to show how long the workflow took to complete and if it's still running then the duration increases on every refresh or poll.

Before: 
<img width="2557" alt="Screenshot 2024-12-12 at 14 31 17" src="https://github.com/user-attachments/assets/24d48134-51a2-44bd-86ba-b82407391c42" />


After: 
<img width="2550" alt="Screenshot 2024-12-12 at 14 27 23" src="https://github.com/user-attachments/assets/baff6e99-0f5f-4c96-9ae1-51a56c7bfeff" />

