### PR TITLE
api: Add Name method to API interface

### DIFF
--- a/_examples/schedule/schedule_test.go
+++ b/_examples/schedule/schedule_test.go
@@ -43,7 +43,7 @@ func TestExampleWorkflow(t *testing.T) {
 	// Give time for go routine to spin up
 	time.Sleep(200 * time.Millisecond)
 
-	_, err := recordStore.Latest(ctx, wf.Name, foreignID)
+	_, err := recordStore.Latest(ctx, wf.Name(), foreignID)
 	// Expect there to be no entries yet
 	require.True(t, errors.Is(err, workflow.ErrRecordNotFound))
 
@@ -52,7 +52,7 @@ func TestExampleWorkflow(t *testing.T) {
 	// Allow scheduling to take place
 	time.Sleep(200 * time.Millisecond)
 
-	firstScheduled, err := recordStore.Latest(ctx, wf.Name, foreignID)
+	firstScheduled, err := recordStore.Latest(ctx, wf.Name(), foreignID)
 	require.Nil(t, err)
 
 	require.Equal(t, "schedule trigger example", firstScheduled.WorkflowName)
@@ -63,7 +63,7 @@ func TestExampleWorkflow(t *testing.T) {
 	// Allow scheduling to take place
 	time.Sleep(200 * time.Millisecond)
 
-	secondScheduled, err := recordStore.Latest(ctx, wf.Name, foreignID)
+	secondScheduled, err := recordStore.Latest(ctx, wf.Name(), foreignID)
 	require.Nil(t, err)
 
 	require.Equal(t, "schedule trigger example", secondScheduled.WorkflowName)

--- a/adapters/webui/internal/frontend/home.html
+++ b/adapters/webui/internal/frontend/home.html
@@ -12,7 +12,7 @@
     <h2 class="text-xl font-bold text-gray-800 dark:text-gray-200 mb-4">Search Filters</h2>
 
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-        <!-- Workflow Name Input -->
+        <!-- Workflow name Input -->
         <div class="flex flex-col">
             <label class="text-gray-600 dark:text-gray-400 font-medium mb-2">Workflow Name</label>
             <input type="text" id="workflowName" placeholder="Enter Workflow Name" class="border border-gray-300 dark:border-gray-700 rounded-lg w-full p-2 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-800 dark:text-gray-300">

--- a/builder.go
+++ b/builder.go
@@ -25,7 +25,7 @@ const (
 func NewBuilder[Type any, Status StatusType](name string) *Builder[Type, Status] {
 	return &Builder[Type, Status]{
 		workflow: &Workflow[Type, Status]{
-			Name:          name,
+			name:          name,
 			clock:         clock.RealClock{},
 			consumers:     make(map[Status]consumerConfig[Type, Status]),
 			callback:      make(map[Status][]callback[Type, Status]),
@@ -46,7 +46,11 @@ type Builder[Type any, Status StatusType] struct {
 	workflow *Workflow[Type, Status]
 }
 
-func (b *Builder[Type, Status]) AddStep(from Status, c ConsumerFunc[Type, Status], allowedDestinations ...Status) *stepUpdater[Type, Status] {
+func (b *Builder[Type, Status]) AddStep(
+	from Status,
+	c ConsumerFunc[Type, Status],
+	allowedDestinations ...Status,
+) *stepUpdater[Type, Status] {
 	if _, exists := b.workflow.consumers[from]; exists {
 		panic("'AddStep(" + from.String() + ",' already exists. Only one Step can be configured to consume the status")
 	}
@@ -101,7 +105,12 @@ func (b *Builder[Type, Status]) AddCallback(from Status, fn CallbackFunc[Type, S
 	b.workflow.callback[from] = append(b.workflow.callback[from], c)
 }
 
-func (b *Builder[Type, Status]) AddTimeout(from Status, timer TimerFunc[Type, Status], tf TimeoutFunc[Type, Status], allowedDestinations ...Status) *timeoutUpdater[Type, Status] {
+func (b *Builder[Type, Status]) AddTimeout(
+	from Status,
+	timer TimerFunc[Type, Status],
+	tf TimeoutFunc[Type, Status],
+	allowedDestinations ...Status,
+) *timeoutUpdater[Type, Status] {
 	timeouts := b.workflow.timeouts[from]
 
 	t := timeout[Type, Status]{
@@ -150,7 +159,11 @@ func (s *timeoutUpdater[Type, Status]) WithOptions(opts ...Option) {
 	s.workflow.timeouts[s.from] = timeout
 }
 
-func (b *Builder[Type, Status]) AddConnector(name string, csc ConnectorConstructor, cf ConnectorFunc[Type, Status]) *connectorUpdater[Type, Status] {
+func (b *Builder[Type, Status]) AddConnector(
+	name string,
+	csc ConnectorConstructor,
+	cf ConnectorFunc[Type, Status],
+) *connectorUpdater[Type, Status] {
 	for _, config := range b.workflow.connectorConfigs {
 		if config.name == name {
 			panic("connector names need to be unique")
@@ -199,7 +212,12 @@ func (b *Builder[Type, Status]) OnComplete(hook RunStateChangeHookFunc[Type, Sta
 	b.workflow.runStateChangeHooks[RunStateCompleted] = hook
 }
 
-func (b *Builder[Type, Status]) Build(eventStreamer EventStreamer, recordStore RecordStore, roleScheduler RoleScheduler, opts ...BuildOption) *Workflow[Type, Status] {
+func (b *Builder[Type, Status]) Build(
+	eventStreamer EventStreamer,
+	recordStore RecordStore,
+	roleScheduler RoleScheduler,
+	opts ...BuildOption,
+) *Workflow[Type, Status] {
 	b.workflow.eventStreamer = eventStreamer
 	b.workflow.recordStore = recordStore
 	b.workflow.scheduler = roleScheduler

--- a/callback_internal_test.go
+++ b/callback_internal_test.go
@@ -16,7 +16,7 @@ import (
 func TestProcessCallback(t *testing.T) {
 	ctx := context.Background()
 	w := &Workflow[string, testStatus]{
-		Name:        "example",
+		name:        "example",
 		ctx:         ctx,
 		clock:       clock_testing.NewFakeClock(time.Date(2024, time.April, 19, 0, 0, 0, 0, time.UTC)),
 		statusGraph: graph.New(),

--- a/connector.go
+++ b/connector.go
@@ -30,12 +30,16 @@ type connectorConfig[Type any, Status StatusType] struct {
 	lagAlert      time.Duration
 }
 
-func connectorConsumer[Type any, Status StatusType](w *Workflow[Type, Status], config *connectorConfig[Type, Status], shard, totalShards int) {
+func connectorConsumer[Type any, Status StatusType](
+	w *Workflow[Type, Status],
+	config *connectorConfig[Type, Status],
+	shard, totalShards int,
+) {
 	role := makeRole(
 		config.name,
 		"connector",
 		"to",
-		w.Name,
+		w.Name(),
 		"consumer",
 		strconv.FormatInt(int64(shard), 10),
 		"of",
@@ -105,7 +109,7 @@ func connectForever[Type any, Status StatusType](
 		}
 
 		// Push metrics and alerting around the age of the event being processed.
-		pushLagMetricAndAlerting(w.Name, processName, e.CreatedAt, lagAlert, w.clock)
+		pushLagMetricAndAlerting(w.Name(), processName, e.CreatedAt, lagAlert, w.clock)
 
 		shouldFilter := FilterConnectorEventUsing(e,
 			shardConnectorEventFilter(shard, totalShards),
@@ -125,7 +129,7 @@ func connectForever[Type any, Status StatusType](
 			return err
 		}
 
-		metrics.ProcessLatency.WithLabelValues(w.Name, processName).Observe(w.clock.Since(t2).Seconds())
+		metrics.ProcessLatency.WithLabelValues(w.Name(), processName).Observe(w.clock.Since(t2).Seconds())
 		return ack()
 	}
 }

--- a/consumer_internal_test.go
+++ b/consumer_internal_test.go
@@ -20,7 +20,7 @@ func TestConsume(t *testing.T) {
 	processName := "processName"
 	testErr := errors.New("test error")
 	w := &Workflow[string, testStatus]{
-		Name:         "example",
+		name:         "example",
 		ctx:          ctx,
 		clock:        clock_testing.NewFakeClock(time.Date(2024, time.April, 19, 0, 0, 0, 0, time.UTC)),
 		errorCounter: counter,

--- a/delete.go
+++ b/delete.go
@@ -12,14 +12,14 @@ import (
 
 func deleteConsumer[Type any, Status StatusType](w *Workflow[Type, Status]) {
 	role := makeRole(
-		w.Name,
+		w.Name(),
 		"delete",
 		"consumer",
 	)
 
 	processName := role
 	w.run(role, processName, func(ctx context.Context) error {
-		topic := DeleteTopic(w.Name)
+		topic := DeleteTopic(w.Name())
 		consumerStream, err := w.eventStreamer.NewConsumer(
 			ctx,
 			topic,
@@ -31,7 +31,17 @@ func deleteConsumer[Type any, Status StatusType](w *Workflow[Type, Status]) {
 		}
 		defer consumerStream.Close()
 
-		return DeleteForever(ctx, w.Name, processName, consumerStream, w.recordStore.Store, w.recordStore.Lookup, w.customDelete, w.defaultOpts.lagAlert, w.clock)
+		return DeleteForever(
+			ctx,
+			w.Name(),
+			processName,
+			consumerStream,
+			w.recordStore.Store,
+			w.recordStore.Lookup,
+			w.customDelete,
+			w.defaultOpts.lagAlert,
+			w.clock,
+		)
 	}, w.defaultOpts.errBackOff)
 }
 

--- a/outbox.go
+++ b/outbox.go
@@ -12,9 +12,13 @@ import (
 	"github.com/luno/workflow/internal/outboxpb"
 )
 
-func outboxConsumer[Type any, Status StatusType](w *Workflow[Type, Status], config outboxConfig, shard, totalShards int) {
+func outboxConsumer[Type any, Status StatusType](
+	w *Workflow[Type, Status],
+	config outboxConfig,
+	shard, totalShards int,
+) {
 	role := makeRole(
-		w.Name,
+		w.Name(),
 		"outbox",
 		"consumer",
 		strconv.FormatInt(int64(shard), 10),
@@ -48,7 +52,19 @@ func outboxConsumer[Type any, Status StatusType](w *Workflow[Type, Status], conf
 	}
 
 	w.run(role, processName, func(ctx context.Context) error {
-		return purgeOutbox[Type, Status](ctx, w.Name, processName, w.recordStore, w.eventStreamer, w.clock, pollingFrequency, lagAlert, config.limit, shard, totalShards)
+		return purgeOutbox[Type, Status](
+			ctx,
+			w.Name(),
+			processName,
+			w.recordStore,
+			w.eventStreamer,
+			w.clock,
+			pollingFrequency,
+			lagAlert,
+			config.limit,
+			shard,
+			totalShards,
+		)
 	}, errBackOff)
 }
 

--- a/runstate_test.go
+++ b/runstate_test.go
@@ -75,7 +75,7 @@ func TestRunState(t *testing.T) {
 
 			time.Sleep(time.Second)
 
-			snapshots := recordStore.Snapshots(w.Name, "fid", runID)
+			snapshots := recordStore.Snapshots(w.Name(), "fid", runID)
 
 			for i, state := range expected {
 				require.Equal(t, state, snapshots[i].RunState)

--- a/state.go
+++ b/state.go
@@ -35,7 +35,7 @@ func (w *Workflow[Type, Status]) updateState(processName string, s State) {
 	w.internalStateMu.Lock()
 	defer w.internalStateMu.Unlock()
 
-	metrics.ProcessStates.WithLabelValues(w.Name, processName).Set(float64(s))
+	metrics.ProcessStates.WithLabelValues(w.Name(), processName).Set(float64(s))
 
 	w.internalState[processName] = s
 }

--- a/timeout_internal_test.go
+++ b/timeout_internal_test.go
@@ -18,7 +18,7 @@ func TestProcessTimeout(t *testing.T) {
 	processName := "processName"
 	testErr := errors.New("test error")
 	w := &Workflow[string, testStatus]{
-		Name:         "example",
+		name:         "example",
 		ctx:          ctx,
 		clock:        clock_testing.NewFakeClock(time.Date(2024, time.April, 19, 0, 0, 0, 0, time.UTC)),
 		errorCounter: counter,

--- a/visualiser.go
+++ b/visualiser.go
@@ -67,7 +67,7 @@ func mermaidDiagram[Type any, Status StatusType](a API[Type, Status], path strin
 	}
 
 	mf := MermaidFormat{
-		WorkflowName:   w.Name,
+		WorkflowName:   w.Name(),
 		Direction:      d,
 		StartingPoints: starting,
 		TerminalPoints: terminal,

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -58,7 +58,7 @@ func (s status) String() string {
 	case StatusInitiated:
 		return "Initiated"
 	case StatusProfileCreated:
-		return "Name Created"
+		return "name Created"
 	case StatusEmailConfirmationSent:
 		return "Email Confirmation Sent"
 	case StatusEmailVerified:
@@ -161,7 +161,7 @@ func TestWorkflowAcceptanceTest(t *testing.T) {
 	_, err = wf.Await(ctx, fid, runID, StatusCompleted)
 	require.Nil(t, err)
 
-	r, err := recordStore.Latest(ctx, "user sign up", fid)
+	r, err := recordStore.Latest(ctx, wf.Name(), fid)
 	require.Nil(t, err)
 	require.Equal(t, int(expectedFinalStatus), r.Status)
 
@@ -601,7 +601,7 @@ func TestStepConsumerLag(t *testing.T) {
 
 	time.Sleep(time.Second)
 
-	latest, err := recordStore.Latest(ctx, wf.Name, foreignID)
+	latest, err := recordStore.Latest(ctx, wf.Name(), foreignID)
 	require.Nil(t, err)
 
 	// Ensure that the record has not been consumer or updated
@@ -613,4 +613,9 @@ func TestStepConsumerLag(t *testing.T) {
 		StartTime:   fixedNowTime,
 		ConsumeTime: fixedNowTime.Add(lagAmount),
 	})
+}
+
+func TestName(t *testing.T) {
+	wf := workflow.NewBuilder[string, status]("test name").Build(nil, nil, nil)
+	require.Equal(t, "test name", wf.Name())
 }

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -58,7 +58,7 @@ func (s status) String() string {
 	case StatusInitiated:
 		return "Initiated"
 	case StatusProfileCreated:
-		return "name Created"
+		return "Name Created"
 	case StatusEmailConfirmationSent:
 		return "Email Confirmation Sent"
 	case StatusEmailVerified:


### PR DESCRIPTION
This renames the `Name` field part of the Workflow struct and makes it a method on the workflow.API interface.