### PR TITLE
connector: Use API interface to improve testability of connector funcs

### DIFF
--- a/_examples/connector/connector.go
+++ b/_examples/connector/connector.go
@@ -50,10 +50,15 @@ func Workflow(d Deps) *workflow.Workflow[GettingStarted, Status] {
 	builder.AddConnector(
 		"my-example-connector",
 		d.Connector,
-		func(ctx context.Context, w *workflow.Workflow[GettingStarted, Status], e *workflow.ConnectorEvent) error {
-			_, err := w.Trigger(ctx, e.ForeignID, StatusStarted, workflow.WithInitialValue[GettingStarted, Status](&GettingStarted{
-				ReadTheDocs: "✅",
-			}))
+		func(ctx context.Context, w workflow.API[GettingStarted, Status], e *workflow.ConnectorEvent) error {
+			_, err := w.Trigger(
+				ctx,
+				e.ForeignID,
+				StatusStarted,
+				workflow.WithInitialValue[GettingStarted, Status](&GettingStarted{
+					ReadTheDocs: "✅",
+				}),
+			)
 			if err != nil {
 				return err
 			}

--- a/adapters/adaptertest/connector.go
+++ b/adapters/adaptertest/connector.go
@@ -34,7 +34,7 @@ func RunConnectorTest(t *testing.T, maker func(seedEvents []workflow.ConnectorEv
 	builder.AddConnector(
 		"tester",
 		constructor,
-		func(ctx context.Context, w *workflow.Workflow[User, SyncStatus], e *workflow.ConnectorEvent) error {
+		func(ctx context.Context, w workflow.API[User, SyncStatus], e *workflow.ConnectorEvent) error {
 			_, err := w.Trigger(ctx, e.ForeignID, SyncStatusStarted, workflow.WithInitialValue[User, SyncStatus](&User{
 				UID: e.ForeignID,
 			}))

--- a/builder_internal_test.go
+++ b/builder_internal_test.go
@@ -232,7 +232,7 @@ func TestAddTimeoutDontAllowLag(t *testing.T) {
 }
 
 func TestConnectorConstruction(t *testing.T) {
-	fn := func(ctx context.Context, w *Workflow[string, testStatus], e *ConnectorEvent) error {
+	fn := func(ctx context.Context, w API[string, testStatus], e *ConnectorEvent) error {
 		return nil
 	}
 

--- a/connector.go
+++ b/connector.go
@@ -17,7 +17,7 @@ type ConnectorConsumer interface {
 	Close() error
 }
 
-type ConnectorFunc[Type any, Status StatusType] func(ctx context.Context, w *Workflow[Type, Status], e *ConnectorEvent) error
+type ConnectorFunc[Type any, Status StatusType] func(ctx context.Context, w API[Type, Status], e *ConnectorEvent) error
 
 type connectorConfig[Type any, Status StatusType] struct {
 	name        string

--- a/state_test.go
+++ b/state_test.go
@@ -38,7 +38,7 @@ func TestInternalState(t *testing.T) {
 	b.AddConnector(
 		"consume-other-stream",
 		memstreamer.NewConnector(nil),
-		func(ctx context.Context, w *workflow.Workflow[string, status], e *workflow.ConnectorEvent) error {
+		func(ctx context.Context, w workflow.API[string, status], e *workflow.ConnectorEvent) error {
 			return nil
 		},
 	).WithOptions(

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -519,7 +519,7 @@ func TestConnector(t *testing.T) {
 	buidler.AddConnector(
 		"my-test-connector",
 		connector,
-		func(ctx context.Context, w *workflow.Workflow[typeX, status], e *workflow.ConnectorEvent) error {
+		func(ctx context.Context, w workflow.API[typeX, status], e *workflow.ConnectorEvent) error {
 			_, err := w.Trigger(ctx, e.ForeignID, StatusStart, workflow.WithInitialValue[typeX, status](&typeX{
 				Val: "trigger set value",
 			}))


### PR DESCRIPTION
This allows the connecto functions to have unit tests written where a mock implementation can be provided as the workflow and not the actual implementation of the workflow. This allows for things like asserting certain calls that should be made back to the workflow without the need to use the actual implementation or providing an empty implementation.