### PR TITLE
recordstore/filter: Convert int64 param to any underlying int variation 

### DIFF
--- a/adapters/adaptertest/recordstore.go
+++ b/adapters/adaptertest/recordstore.go
@@ -237,7 +237,7 @@ func testList(t *testing.T, factory func() workflow.RecordStore) {
 				0,
 				100,
 				workflow.OrderTypeAscending,
-				workflow.FilterByStatus(int64(status)),
+				workflow.FilterByStatus(status),
 			)
 			require.Nil(t, err)
 			require.Equal(t, count, len(ls))
@@ -360,7 +360,7 @@ func testList(t *testing.T, factory func() workflow.RecordStore) {
 				0,
 				100,
 				workflow.OrderTypeAscending,
-				workflow.FilterByStatus(int64(status)),
+				workflow.FilterByStatus(status),
 			)
 			require.Nil(t, err)
 			require.Equal(t, count, len(ls))

--- a/adapters/webui/internal/api/list.go
+++ b/adapters/webui/internal/api/list.go
@@ -67,7 +67,7 @@ func List(listRecords ListWorkflowRecords, stringer Stringer) http.HandlerFunc {
 		}
 
 		if req.FilterByStatus != 0 {
-			filters = append(filters, workflow.FilterByStatus(int64(req.FilterByStatus)))
+			filters = append(filters, workflow.FilterByStatus(req.FilterByStatus))
 		}
 
 		list, err := listRecords(r.Context(), req.WorkflowName, req.Offset, req.Limit, order, filters...)

--- a/filter.go
+++ b/filter.go
@@ -1,6 +1,8 @@
 package workflow
 
-import "strconv"
+import (
+	"strconv"
+)
 
 func MakeFilter(filters ...RecordFilter) *recordFilters {
 	var rf recordFilters
@@ -49,7 +51,7 @@ func FilterByForeignID(val string) RecordFilter {
 	}
 }
 
-func FilterByStatus[statusType ~int | ~int32 | ~int64](status statusType) RecordFilter {
+func FilterByStatus[statusType ~int | ~int8 | ~int16 | ~int32 | ~int64](status statusType) RecordFilter {
 	return func(filters *recordFilters) {
 		i := strconv.FormatInt(int64(status), 10)
 		filters.byStatus = makeFilterValue(i)

--- a/filter.go
+++ b/filter.go
@@ -49,9 +49,9 @@ func FilterByForeignID(val string) RecordFilter {
 	}
 }
 
-func FilterByStatus(status int64) RecordFilter {
+func FilterByStatus[statusType ~int | ~int32 | ~int64](status statusType) RecordFilter {
 	return func(filters *recordFilters) {
-		i := strconv.FormatInt(status, 10)
+		i := strconv.FormatInt(int64(status), 10)
 		filters.byStatus = makeFilterValue(i)
 	}
 }


### PR DESCRIPTION
This MR changes the `FilterByStatus` function to take in anything that is a underlying int, int32, or int64 so that aliases may be passed in such as the status that is being used. The `StatusType` is not being used as the stringer is not needed.