### PR TITLE
testing: Return pointer of workflow run for constructor `NewTestingRun`

### DIFF
--- a/autopause_internal_test.go
+++ b/autopause_internal_test.go
@@ -78,7 +78,7 @@ func Test_maybeAutoPause(t *testing.T) {
 				counter,
 				testErr,
 				processName,
-				&r,
+				r,
 				&logger{},
 			)
 			require.ErrorIs(t, err, tc.expectedErr)

--- a/run_test.go
+++ b/run_test.go
@@ -21,3 +21,13 @@ func TestNewTestingRun(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, status(workflow.SkipTypeRunStateUpdate), cancelStatus)
 }
+
+func TestNewTestingRun_requiresTestingParam(t *testing.T) {
+	require.PanicsWithValue(t,
+		"Cannot use NewTestingRun without *testing.T parameter",
+		func() {
+			_ = workflow.NewTestingRun[string, status](nil, workflow.Record{}, "test")
+		},
+	)
+
+}

--- a/testing.go
+++ b/testing.go
@@ -179,13 +179,17 @@ func NewTestingRun[Type any, Status StatusType](
 	wr Record,
 	object Type,
 	opts ...TestingRunOption,
-) Run[Type, Status] {
+) *Run[Type, Status] {
+	if t == nil {
+		panic("Cannot use NewTestingRun without *testing.T parameter")
+	}
+
 	var options testingRunOpts
 	for _, opt := range opts {
 		opt(&options)
 	}
 
-	return Run[Type, Status]{
+	return &Run[Type, Status]{
 		TypedRecord: TypedRecord[Type, Status]{
 			Record: wr,
 			Status: Status(wr.Status),


### PR DESCRIPTION
This MR changes NewTestingRun to return a pointer to the run. This is to align with the norm that `New` returns a pointer.