### PR TITLE
workflow: Allow passing API into testing utility functions

### DIFF
--- a/_examples/connector/connector.go
+++ b/_examples/connector/connector.go
@@ -50,8 +50,8 @@ func Workflow(d Deps) *workflow.Workflow[GettingStarted, Status] {
 	builder.AddConnector(
 		"my-example-connector",
 		d.Connector,
-		func(ctx context.Context, w workflow.API[GettingStarted, Status], e *workflow.ConnectorEvent) error {
-			_, err := w.Trigger(
+		func(ctx context.Context, api workflow.API[GettingStarted, Status], e *workflow.ConnectorEvent) error {
+			_, err := api.Trigger(
 				ctx,
 				e.ForeignID,
 				StatusStarted,

--- a/adapters/adaptertest/connector.go
+++ b/adapters/adaptertest/connector.go
@@ -34,10 +34,15 @@ func RunConnectorTest(t *testing.T, maker func(seedEvents []workflow.ConnectorEv
 	builder.AddConnector(
 		"tester",
 		constructor,
-		func(ctx context.Context, w workflow.API[User, SyncStatus], e *workflow.ConnectorEvent) error {
-			_, err := w.Trigger(ctx, e.ForeignID, SyncStatusStarted, workflow.WithInitialValue[User, SyncStatus](&User{
-				UID: e.ForeignID,
-			}))
+		func(ctx context.Context, api workflow.API[User, SyncStatus], e *workflow.ConnectorEvent) error {
+			_, err := api.Trigger(
+				ctx,
+				e.ForeignID,
+				SyncStatusStarted,
+				workflow.WithInitialValue[User, SyncStatus](&User{
+					UID: e.ForeignID,
+				}),
+			)
 			if err != nil {
 				return err
 			}

--- a/adapters/jlog/jlog_test.go
+++ b/adapters/jlog/jlog_test.go
@@ -37,8 +37,8 @@ func TestError(t *testing.T) {
 	expected := `E 00:00:00.000 g/l/w/a/jlog/jlog.go:23: error(s) 
   test error
   - github.com/luno/workflow/adapters/jlog/jlog_test.go:34 TestError
-  - testing/testing.go:1689 tRunner
-  - runtime/asm_arm64.s:1222 goexit
+  - testing/testing.go:1690 tRunner
+  - runtime/asm_arm64.s:1223 goexit
 `
 	require.Equal(t, expected, buf.String())
 }

--- a/connector.go
+++ b/connector.go
@@ -17,7 +17,7 @@ type ConnectorConsumer interface {
 	Close() error
 }
 
-type ConnectorFunc[Type any, Status StatusType] func(ctx context.Context, w API[Type, Status], e *ConnectorEvent) error
+type ConnectorFunc[Type any, Status StatusType] func(ctx context.Context, api API[Type, Status], e *ConnectorEvent) error
 
 type connectorConfig[Type any, Status StatusType] struct {
 	name        string

--- a/state_test.go
+++ b/state_test.go
@@ -38,7 +38,7 @@ func TestInternalState(t *testing.T) {
 	b.AddConnector(
 		"consume-other-stream",
 		memstreamer.NewConnector(nil),
-		func(ctx context.Context, w workflow.API[string, status], e *workflow.ConnectorEvent) error {
+		func(ctx context.Context, api workflow.API[string, status], e *workflow.ConnectorEvent) error {
 			return nil
 		},
 	).WithOptions(

--- a/testing.go
+++ b/testing.go
@@ -13,13 +13,18 @@ import (
 
 func TriggerCallbackOn[Type any, Status StatusType, Payload any](
 	t testing.TB,
-	w *Workflow[Type, Status],
+	api API[Type, Status],
 	foreignID, runID string,
 	waitForStatus Status,
 	p Payload,
 ) {
 	if t == nil {
 		panic("TriggerCallbackOn can only be used for testing")
+	}
+
+	w, ok := api.(*Workflow[Type, Status])
+	if !ok {
+		panic("*workflow.Workflow required for testing utility functions")
 	}
 
 	_ = waitFor(t, w, foreignID, func(r *Record) (bool, error) {
@@ -35,12 +40,17 @@ func TriggerCallbackOn[Type any, Status StatusType, Payload any](
 
 func AwaitTimeoutInsert[Type any, Status StatusType](
 	t testing.TB,
-	w *Workflow[Type, Status],
+	api API[Type, Status],
 	foreignID, runID string,
 	waitFor Status,
 ) {
 	if t == nil {
 		panic("AwaitTimeoutInsert can only be used for testing")
+	}
+
+	w, ok := api.(*Workflow[Type, Status])
+	if !ok {
+		panic("*workflow.Workflow required for testing utility functions")
 	}
 
 	var found bool
@@ -73,13 +83,18 @@ func AwaitTimeoutInsert[Type any, Status StatusType](
 
 func Require[Type any, Status StatusType](
 	t testing.TB,
-	w *Workflow[Type, Status],
+	api API[Type, Status],
 	foreignID string,
 	waitForStatus Status,
 	expected Type,
 ) {
 	if t == nil {
 		panic("Require can only be used for testing")
+	}
+
+	w, ok := api.(*Workflow[Type, Status])
+	if !ok {
+		panic("*workflow.Workflow required for testing utility functions")
 	}
 
 	if !w.statusGraph.IsValid(int(waitForStatus)) {
@@ -114,12 +129,17 @@ func Require[Type any, Status StatusType](
 
 func WaitFor[Type any, Status StatusType](
 	t testing.TB,
-	w *Workflow[Type, Status],
+	api API[Type, Status],
 	foreignID string,
 	fn func(r *Run[Type, Status]) (bool, error),
 ) {
 	if t == nil {
 		panic("WaitFor can only be used for testing")
+	}
+
+	w, ok := api.(*Workflow[Type, Status])
+	if !ok {
+		panic("*workflow.Workflow required for testing utility functions")
 	}
 
 	waitFor(t, w, foreignID, func(r *Record) (bool, error) {

--- a/testing_test.go
+++ b/testing_test.go
@@ -3,6 +3,7 @@ package workflow_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -24,6 +25,15 @@ func TestTriggerCallbackOn_validation(t *testing.T) {
 			}, "Not providing a testing.T or testing.B should panic")
 	})
 
+	t.Run("TriggerCallbackOn must be provided with a workflow.Workflow", func(t *testing.T) {
+		require.PanicsWithValue(t,
+			"*workflow.Workflow required for testing utility functions",
+			func() {
+				api := &apiImpl[string, status]{}
+				workflow.Require(t, api, "", StatusEnd, "")
+			}, "Not providing a workflow using a TestingRecordStore implemented record store should panic")
+	})
+
 	t.Run("TriggerCallbackOn must be provided with a workflow that is using a record store that implements TestingRecordStore", func(t *testing.T) {
 		require.PanicsWithValue(t,
 			"TestingRecordStore implementation for record store dependency required",
@@ -33,13 +43,13 @@ func TestTriggerCallbackOn_validation(t *testing.T) {
 					return r.Cancel(ctx)
 				}, StatusEnd)
 
-				wf := b.Build(
+				w := b.Build(
 					memstreamer.New(),
 					nil,
 					memrolescheduler.New(),
 				)
 
-				workflow.Require(t, wf, "", StatusEnd, "")
+				workflow.TriggerCallbackOn(t, w, "", "", StatusEnd, "")
 			}, "Not providing a workflow using a TestingRecordStore implemented record store should panic")
 	})
 }
@@ -69,6 +79,15 @@ func TestAwaitTimeoutInsert_validation(t *testing.T) {
 				)
 
 				workflow.Require(t, wf, "", StatusEnd, "")
+			}, "Not providing a workflow using a TestingRecordStore implemented record store should panic")
+	})
+
+	t.Run("AwaitTimeoutInsert must be provided with a *workflow.Workflow", func(t *testing.T) {
+		require.PanicsWithValue(t,
+			"*workflow.Workflow required for testing utility functions",
+			func() {
+				api := &apiImpl[string, status]{}
+				workflow.AwaitTimeoutInsert(t, api, "", "", StatusEnd)
 			}, "Not providing a workflow using a TestingRecordStore implemented record store should panic")
 	})
 }
@@ -124,6 +143,15 @@ func TestRequire_validation(t *testing.T) {
 				workflow.Require(t, wf, "", StatusEnd, "")
 			}, "Not providing a workflow using a TestingRecordStore implemented record store should panic")
 	})
+
+	t.Run("Require must be provided with a *workflow.Workflow", func(t *testing.T) {
+		require.PanicsWithValue(t,
+			"*workflow.Workflow required for testing utility functions",
+			func() {
+				api := &apiImpl[string, status]{}
+				workflow.Require(t, api, "", StatusEnd, "")
+			}, "Not providing a workflow using a TestingRecordStore implemented record store should panic")
+	})
 }
 
 // testCustomMarshaler is for testing and implements custom and weird behaviour via the
@@ -160,3 +188,31 @@ func TestWaitFor(t *testing.T) {
 		return r.RunState == workflow.RunStateCompleted, nil
 	})
 }
+
+var _ workflow.API[string, status] = (*apiImpl[string, status])(nil)
+
+type apiImpl[Type any, Status workflow.StatusType] struct{}
+
+func (a apiImpl[Type, Status]) Name() string {
+	return "test"
+}
+
+func (a apiImpl[Type, Status]) Trigger(ctx context.Context, foreignID string, startingStatus Status, opts ...workflow.TriggerOption[Type, Status]) (runID string, err error) {
+	return "", nil
+}
+
+func (a apiImpl[Type, Status]) Schedule(foreignID string, startingStatus Status, spec string, opts ...workflow.ScheduleOption[Type, Status]) error {
+	return nil
+}
+
+func (a apiImpl[Type, Status]) Await(ctx context.Context, foreignID, runID string, status Status, opts ...workflow.AwaitOption) (*workflow.Run[Type, Status], error) {
+	return &workflow.Run[Type, Status]{}, nil
+}
+
+func (a apiImpl[Type, Status]) Callback(ctx context.Context, foreignID string, status Status, payload io.Reader) error {
+	return nil
+}
+
+func (a apiImpl[Type, Status]) Run(ctx context.Context) {}
+
+func (a apiImpl[Type, Status]) Stop() {}

--- a/workflow.go
+++ b/workflow.go
@@ -292,3 +292,12 @@ func (w *Workflow[Type, Status]) Stop() {
 		}
 	}
 }
+
+func workflowImplementation[Type any, Status StatusType](api API[Type, Status]) *Workflow[Type, Status] {
+	w, ok := api.(*Workflow[Type, Status])
+	if !ok {
+		panic("*workflow.Workflow required for testing utility functions")
+	}
+
+	return w
+}

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -519,8 +519,8 @@ func TestConnector(t *testing.T) {
 	buidler.AddConnector(
 		"my-test-connector",
 		connector,
-		func(ctx context.Context, w workflow.API[typeX, status], e *workflow.ConnectorEvent) error {
-			_, err := w.Trigger(ctx, e.ForeignID, StatusStart, workflow.WithInitialValue[typeX, status](&typeX{
+		func(ctx context.Context, api workflow.API[typeX, status], e *workflow.ConnectorEvent) error {
+			_, err := api.Trigger(ctx, e.ForeignID, StatusStart, workflow.WithInitialValue[typeX, status](&typeX{
 				Val: "trigger set value",
 			}))
 			if err != nil {


### PR DESCRIPTION
This allows for users to return a workflow.API from a function and still use the testing functions as long as the underlying type is a *workflow.Workflow and not, for instance, a mock implementation.