### PR TITLE
sqlstore: Use writer instance for time critical read

### DIFF
--- a/adapters/sqlstore/sqlstore.go
+++ b/adapters/sqlstore/sqlstore.go
@@ -117,7 +117,7 @@ func (s *SQLStore) ListOutboxEvents(
 	workflowName string,
 	limit int64,
 ) ([]workflow.OutboxEvent, error) {
-	return s.listOutboxWhere(ctx, s.reader, "workflow_name=? limit ?", workflowName, limit)
+	return s.listOutboxWhere(ctx, s.writer, "workflow_name=? limit ?", workflowName, limit)
 }
 
 func (s *SQLStore) DeleteOutboxEvent(ctx context.Context, id string) error {


### PR DESCRIPTION
If a replica exists then there is a good chance, at low polling frequency, that old outbox records will be listed. This ensures that the time critical changes are always accurate. The table cannot grow very large due to the deletion after processing so this should be sustainable.