### PR TITLE
outbox: Align with default options pattern and test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
   core:
     strategy:
       matrix:
-        go: [ '1.22', '1' ]
+        go: [ '1.23', '1' ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -351,7 +351,9 @@ func TestRunStateChanges(t *testing.T) {
 		memstreamer.New(),
 		memrecordstore.New(),
 		memrolescheduler.New(),
-		workflow.WithOutboxPollingFrequency(time.Millisecond),
+		workflow.WithOutboxOptions(
+			workflow.OutboxPollingFrequency(time.Millisecond),
+		),
 	)
 
 	ctx := context.Background()
@@ -384,7 +386,6 @@ func TestMetricProcessSkippedEvents(t *testing.T) {
 		memstreamer.New(),
 		memrecordstore.New(),
 		memrolescheduler.New(),
-		workflow.WithOutboxPollingFrequency(time.Millisecond),
 	)
 
 	ctx := context.Background()

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -111,22 +111,10 @@ func TestMetricProcessStates(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 500)
 
-	expected := `
-# HELP workflow_process_states The current states of all the processes
-# TYPE workflow_process_states gauge
-workflow_process_states{process_name="delete-consumer",workflow_name="example"} 2
-workflow_process_states{process_name="outbox-consumer",workflow_name="example"} 2
-workflow_process_states{process_name="start-consumer-1-of-1",workflow_name="example"} 2
-workflow_process_states{process_name="paused-records-retry-consumer",workflow_name="example"} 2
-`
-
-	err := testutil.CollectAndCompare(metrics.ProcessStates, strings.NewReader(expected))
-	require.Nil(t, err)
-
 	w.Stop()
 
 	// Ensure that the metrics are updated to false when stopping the process
-	expected = `
+	expected := `
 # HELP workflow_process_states The current states of all the processes
 # TYPE workflow_process_states gauge
 workflow_process_states{process_name="delete-consumer",workflow_name="example"} 1
@@ -135,7 +123,7 @@ workflow_process_states{process_name="outbox-consumer",workflow_name="example"} 
 workflow_process_states{process_name="paused-records-retry-consumer",workflow_name="example"} 1
 `
 
-	err = testutil.CollectAndCompare(metrics.ProcessStates, strings.NewReader(expected))
+	err := testutil.CollectAndCompare(metrics.ProcessStates, strings.NewReader(expected))
 	require.Nil(t, err)
 
 	metrics.ProcessStates.Reset()

--- a/runstate_test.go
+++ b/runstate_test.go
@@ -103,7 +103,6 @@ func buildWorkflow(fn workflow.ConsumerFunc[string, status]) func(recordStore wo
 			recordStore,
 			memrolescheduler.New(),
 			workflow.WithDebugMode(),
-			workflow.WithOutboxPollingFrequency(time.Millisecond*5),
 		)
 
 		return w

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -214,7 +214,6 @@ func benchmarkWorkflow(b *testing.B, numberOfSteps int) {
 		recordStore,
 		memrolescheduler.New(),
 		workflow.WithClock(clock),
-		workflow.WithOutboxPollingFrequency(1*time.Nanosecond),
 		workflow.WithDefaultOptions(
 			workflow.PollingFrequency(1*time.Nanosecond),
 		),


### PR DESCRIPTION
The outbox options had a different pattern than the default options for the processes and this aligns with that pattern plus additional unit tests.
