### PR TITLE
workflow/record: Add metadata for debug and replication lag resilience

### DIFF
--- a/_examples/webui/main.go
+++ b/_examples/webui/main.go
@@ -33,14 +33,6 @@ func main() {
 		}
 	}
 
-	rec, err := recordStore.Latest(ctx, ExampleWorkflowName, "Customer 2")
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Println("Trace: ")
-	fmt.Println(rec.Meta.TraceOrigin)
-
 	paths := webui.Paths{
 		List:       "/api/v1/list",
 		Update:     "/api/v1/record/update",
@@ -62,7 +54,7 @@ func main() {
 
 	fmt.Println("Head on over to 'http://localhost:9492' to view!")
 
-	err = http.ListenAndServe("localhost:9492", nil)
+	err := http.ListenAndServe("localhost:9492", nil)
 	if err != nil {
 		panic(err)
 	}

--- a/_examples/webui/main.go
+++ b/_examples/webui/main.go
@@ -33,6 +33,14 @@ func main() {
 		}
 	}
 
+	rec, err := recordStore.Latest(ctx, ExampleWorkflowName, "Customer 2")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Trace: ")
+	fmt.Println(rec.Meta.TraceOrigin)
+
 	paths := webui.Paths{
 		List:       "/api/v1/list",
 		Update:     "/api/v1/record/update",
@@ -54,7 +62,7 @@ func main() {
 
 	fmt.Println("Head on over to 'http://localhost:9492' to view!")
 
-	err := http.ListenAndServe("localhost:9492", nil)
+	err = http.ListenAndServe("localhost:9492", nil)
 	if err != nil {
 		panic(err)
 	}
@@ -118,11 +126,11 @@ func Example(rs workflow.RecordStore) *workflow.Workflow[ExampleData, Status] {
 		StatusMiddle,
 		func(ctx context.Context, r *workflow.Run[ExampleData, Status]) (Status, error) {
 			if r.ForeignID == "Customer 2" {
-				return r.Pause(ctx)
+				return r.Pause(ctx, "Always pause customer 2")
 			}
 
 			if r.ForeignID == "Customer 1" {
-				return r.Cancel(ctx)
+				return r.Cancel(ctx, "Always cancel Customer 1")
 			}
 
 			*r.Object = ExampleData{

--- a/_examples/webui/main.go
+++ b/_examples/webui/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 
 	"github.com/luno/workflow"
 	"github.com/luno/workflow/adapters/memrecordstore"
@@ -41,13 +40,6 @@ func main() {
 	http.HandleFunc("/", webui.HomeHandlerFunc(paths))
 	http.HandleFunc(paths.List, webui.ListHandlerFunc(
 		recordStore,
-		func(workflowName string, enumValue int) string {
-			if workflowName == ExampleWorkflowName {
-				return Status(enumValue).String()
-			}
-
-			return strconv.Itoa(enumValue)
-		},
 	))
 	http.HandleFunc(paths.ObjectData, webui.ObjectDataHandlerFunc(recordStore))
 	http.HandleFunc(paths.Update, webui.UpdateHandlerFunc(recordStore))

--- a/adapters/memrecordstore/memrecordstore.go
+++ b/adapters/memrecordstore/memrecordstore.go
@@ -84,6 +84,7 @@ func (s *Store) Lookup(ctx context.Context, id string) (*workflow.Record, error)
 		Object:       record.Object,
 		CreatedAt:    record.CreatedAt,
 		UpdatedAt:    record.UpdatedAt,
+		Meta:         record.Meta,
 	}, nil
 }
 
@@ -138,6 +139,7 @@ func (s *Store) Latest(ctx context.Context, workflowName, foreignID string) (*wo
 		Object:       record.Object,
 		CreatedAt:    record.CreatedAt,
 		UpdatedAt:    record.UpdatedAt,
+		Meta:         record.Meta,
 	}, nil
 }
 

--- a/adapters/sqlstore/schema.sql
+++ b/adapters/sqlstore/schema.sql
@@ -5,9 +5,10 @@ create table workflow_records (
     run_id                 varchar(255) not null,
     run_state              int not null,
     status                 int not null,
-    object                 longblob not null,
+    object                 JSON not null,
     created_at             datetime(3) not null,
     updated_at             datetime(3) not null,
+    meta                   JSON not null,
 
     primary key(run_id),
 
@@ -22,5 +23,7 @@ create table workflow_outbox (
     data               blob,
     created_at         datetime(3) not null,
 
-    primary key (id)
+    primary key (id),
+
+    index by_workflow_name (workflow_name)
 );

--- a/adapters/sqlstore/schema.sql
+++ b/adapters/sqlstore/schema.sql
@@ -5,10 +5,10 @@ create table workflow_records (
     run_id                 varchar(255) not null,
     run_state              int not null,
     status                 int not null,
-    object                 JSON not null,
+    object                 longblob not null,
     created_at             datetime(3) not null,
     updated_at             datetime(3) not null,
-    meta                   JSON not null,
+    meta                   blob not null,
 
     primary key(run_id),
 

--- a/adapters/sqlstore/sqlstore.go
+++ b/adapters/sqlstore/sqlstore.go
@@ -33,7 +33,7 @@ func New(writer *sql.DB, reader *sql.DB, recordTableName string, outboxTableName
 		outboxTableName: outboxTableName,
 	}
 
-	e.recordCols = " `workflow_name`, `foreign_id`, `run_id`, `run_state`, `status`, `object`, `created_at`, `updated_at` "
+	e.recordCols = " `workflow_name`, `foreign_id`, `run_id`, `run_state`, `status`, `object`, `created_at`, `updated_at`, `meta` "
 	e.recordSelectPrefix = " select " + e.recordCols + " from " + e.recordTableName + " where "
 
 	e.outboxCols = " `id`, `workflow_name`, `data`, `created_at` "
@@ -65,12 +65,12 @@ func (s *SQLStore) Store(ctx context.Context, r *workflow.Record) error {
 	}
 
 	if mustCreate {
-		err := s.create(ctx, tx, r.WorkflowName, r.ForeignID, r.RunID, r.Status, r.Object, int(r.RunState))
+		err := s.create(ctx, tx, r.WorkflowName, r.ForeignID, r.RunID, r.Status, r.Object, int(r.RunState), r.Meta)
 		if err != nil {
 			return err
 		}
 	} else {
-		err := s.update(ctx, tx, r.RunID, r.Status, r.Object, int(r.RunState))
+		err := s.update(ctx, tx, r.RunID, r.Status, r.Object, int(r.RunState), r.Meta)
 		if err != nil {
 			return err
 		}

--- a/adapters/sqlstore/util_test.go
+++ b/adapters/sqlstore/util_test.go
@@ -16,14 +16,16 @@ var migrations = []string{
 		run_id                 varchar(255) not null,
 		run_state              int not null,
 		status                 int not null,
-		object                 longblob not null,
+		object                 JSON not null,
 		created_at             datetime(3) not null,
 		updated_at             datetime(3) not null,
+		meta                   JSON not null,
 	
 		primary key(run_id),
 	
-		index by_workflow_name_foreign_id_run_id_status (workflow_name, foreign_id, run_id, status),
-		index by_run_state (run_state)
+		index by_workflow_name_foreign_id_status (workflow_name, foreign_id, status),
+    	index by_run_state (run_state),
+    	index by_created_at (created_at)
 	)`,
 	`
 	create table workflow_outbox (
@@ -32,7 +34,9 @@ var migrations = []string{
 		data               blob,
 		created_at         datetime(3) not null,
 	
-		primary key (id)
+		primary key (id),
+		
+		index by_workflow_name (workflow_name)
 	)
 `,
 }

--- a/adapters/sqlstore/util_test.go
+++ b/adapters/sqlstore/util_test.go
@@ -24,8 +24,8 @@ var migrations = []string{
 		primary key(run_id),
 	
 		index by_workflow_name_foreign_id_status (workflow_name, foreign_id, status),
-    	index by_run_state (run_state),
-    	index by_created_at (created_at)
+		index by_run_state (run_state),
+		index by_created_at (created_at)
 	)`,
 	`
 	create table workflow_outbox (

--- a/adapters/sqlstore/util_test.go
+++ b/adapters/sqlstore/util_test.go
@@ -16,10 +16,10 @@ var migrations = []string{
 		run_id                 varchar(255) not null,
 		run_state              int not null,
 		status                 int not null,
-		object                 JSON not null,
+		object                 longblob not null,
 		created_at             datetime(3) not null,
 		updated_at             datetime(3) not null,
-		meta                   JSON not null,
+		meta                   blob not null,
 	
 		primary key(run_id),
 	

--- a/adapters/webui/internal/api/list.go
+++ b/adapters/webui/internal/api/list.go
@@ -26,18 +26,21 @@ type ListResponse struct {
 
 // ListItem is a lightweight version of workflow.Record
 type ListItem struct {
-	WorkflowName string    `json:"workflow_name"`
-	ForeignID    string    `json:"foreign_id"`
-	RunID        string    `json:"run_id"`
-	RunState     string    `json:"run_state"`
-	Status       string    `json:"status"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	WorkflowName   string    `json:"workflow_name"`
+	ForeignID      string    `json:"foreign_id"`
+	RunID          string    `json:"run_id"`
+	RunState       string    `json:"run_state"`
+	RunStateReason string    `json:"run_state_reason"`
+	Status         string    `json:"status"`
+	Version        uint      `json:"version"`
+	TraceOrigin    string    `json:"trace_origin"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
 }
 
 type ListWorkflowRecords func(ctx context.Context, workflowName string, offset int64, limit int, order workflow.OrderType, filters ...workflow.RecordFilter) ([]workflow.Record, error)
 
-func List(listRecords ListWorkflowRecords, stringer Stringer) http.HandlerFunc {
+func List(listRecords ListWorkflowRecords) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -78,15 +81,17 @@ func List(listRecords ListWorkflowRecords, stringer Stringer) http.HandlerFunc {
 
 		var listItems []ListItem
 		for _, record := range list {
-			statusName := stringer(record.WorkflowName, record.Status)
 			listItems = append(listItems, ListItem{
-				WorkflowName: record.WorkflowName,
-				ForeignID:    record.ForeignID,
-				RunID:        record.RunID,
-				RunState:     record.RunState.String(),
-				Status:       statusName,
-				CreatedAt:    record.CreatedAt,
-				UpdatedAt:    record.UpdatedAt,
+				WorkflowName:   record.WorkflowName,
+				ForeignID:      record.ForeignID,
+				RunID:          record.RunID,
+				RunState:       record.RunState.String(),
+				RunStateReason: record.Meta.RunStateReason,
+				Status:         record.Meta.StatusDescription,
+				Version:        record.Meta.Version,
+				TraceOrigin:    record.Meta.TraceOrigin,
+				CreatedAt:      record.CreatedAt,
+				UpdatedAt:      record.UpdatedAt,
 			})
 		}
 

--- a/adapters/webui/internal/api/list_test.go
+++ b/adapters/webui/internal/api/list_test.go
@@ -195,15 +195,15 @@ func TestListHandler(t *testing.T) {
 					filter := workflow.MakeFilter(filters...)
 					if tc.request.FilterByRunState != 0 {
 						require.True(t, filter.ByRunState().Enabled)
-						require.Equal(t, fmt.Sprintf("%v", tc.request.FilterByRunState), filter.ByRunState().Value)
+						require.Equal(t, fmt.Sprintf("%v", tc.request.FilterByRunState), filter.ByRunState().Value())
 					}
 					if tc.request.FilterByForeignID != "" {
 						require.True(t, filter.ByForeignID().Enabled)
-						require.Equal(t, tc.request.FilterByForeignID, filter.ByForeignID().Value)
+						require.Equal(t, tc.request.FilterByForeignID, filter.ByForeignID().Value())
 					}
 					if tc.request.FilterByStatus != 0 {
 						require.True(t, filter.ByStatus().Enabled)
-						require.Equal(t, fmt.Sprintf("%v", tc.request.FilterByStatus), filter.ByStatus().Value)
+						require.Equal(t, fmt.Sprintf("%v", tc.request.FilterByStatus), filter.ByStatus().Value())
 					}
 
 					return tc.listResponse, nil

--- a/adapters/webui/internal/api/list_test.go
+++ b/adapters/webui/internal/api/list_test.go
@@ -36,7 +36,9 @@ func TestListHandler(t *testing.T) {
 					WorkflowName: "test",
 					ForeignID:    "9",
 					RunState:     workflow.RunStateCompleted,
-					Status:       9,
+					Meta: workflow.Meta{
+						StatusDescription: "Start",
+					},
 				},
 			},
 			expectedResponse: api.ListResponse{
@@ -45,7 +47,7 @@ func TestListHandler(t *testing.T) {
 						WorkflowName: "test",
 						ForeignID:    "9",
 						RunState:     workflow.RunStateCompleted.String(),
-						Status:       "9",
+						Status:       "Start",
 					},
 				},
 			},
@@ -64,13 +66,17 @@ func TestListHandler(t *testing.T) {
 					WorkflowName: "test",
 					ForeignID:    "9",
 					RunState:     workflow.RunStateCompleted,
-					Status:       9,
+					Meta: workflow.Meta{
+						StatusDescription: "Start",
+					},
 				},
 				{
 					WorkflowName: "test",
 					ForeignID:    "9",
 					RunState:     workflow.RunStateCompleted,
-					Status:       9,
+					Meta: workflow.Meta{
+						StatusDescription: "Start",
+					},
 				},
 			},
 			expectedResponse: api.ListResponse{
@@ -79,13 +85,13 @@ func TestListHandler(t *testing.T) {
 						WorkflowName: "test",
 						ForeignID:    "9",
 						RunState:     workflow.RunStateCompleted.String(),
-						Status:       "9",
+						Status:       "Start",
 					},
 					{
 						WorkflowName: "test",
 						ForeignID:    "9",
 						RunState:     workflow.RunStateCompleted.String(),
-						Status:       "9",
+						Status:       "Start",
 					},
 				},
 			},
@@ -105,7 +111,9 @@ func TestListHandler(t *testing.T) {
 					WorkflowName: "test",
 					ForeignID:    "9",
 					RunState:     workflow.RunStateCompleted,
-					Status:       9,
+					Meta: workflow.Meta{
+						StatusDescription: "Start",
+					},
 				},
 			},
 			expectedResponse: api.ListResponse{
@@ -114,7 +122,7 @@ func TestListHandler(t *testing.T) {
 						WorkflowName: "test",
 						ForeignID:    "9",
 						RunState:     workflow.RunStateCompleted.String(),
-						Status:       "9",
+						Status:       "Start",
 					},
 				},
 			},
@@ -134,7 +142,9 @@ func TestListHandler(t *testing.T) {
 					WorkflowName: "test",
 					ForeignID:    "9",
 					RunState:     workflow.RunStateCompleted,
-					Status:       9,
+					Meta: workflow.Meta{
+						StatusDescription: "Start",
+					},
 				},
 			},
 			expectedResponse: api.ListResponse{
@@ -143,7 +153,7 @@ func TestListHandler(t *testing.T) {
 						WorkflowName: "test",
 						ForeignID:    "9",
 						RunState:     workflow.RunStateCompleted.String(),
-						Status:       "9",
+						Status:       "Start",
 					},
 				},
 			},
@@ -163,7 +173,9 @@ func TestListHandler(t *testing.T) {
 					WorkflowName: "test",
 					ForeignID:    "9",
 					RunState:     workflow.RunStateCompleted,
-					Status:       9,
+					Meta: workflow.Meta{
+						StatusDescription: "Start",
+					},
 				},
 			},
 			expectedResponse: api.ListResponse{
@@ -172,7 +184,7 @@ func TestListHandler(t *testing.T) {
 						WorkflowName: "test",
 						ForeignID:    "9",
 						RunState:     workflow.RunStateCompleted.String(),
-						Status:       "9",
+						Status:       "Start",
 					},
 				},
 			},
@@ -208,9 +220,7 @@ func TestListHandler(t *testing.T) {
 
 					return tc.listResponse, nil
 				}
-				api.List(listFn, func(workflowName string, enumValue int) string {
-					return "9"
-				})(w, r)
+				api.List(listFn)(w, r)
 			}))
 			t.Cleanup(srv.Close)
 

--- a/adapters/webui/internal/api/update.go
+++ b/adapters/webui/internal/api/update.go
@@ -43,7 +43,7 @@ func Update(store workflow.RecordStore) http.HandlerFunc {
 
 		switch req.Action {
 		case "pause":
-			err = ctr.Pause(r.Context())
+			err = ctr.Pause(r.Context(), "")
 			if err != nil {
 				http.Error(w, "failed to pause record", http.StatusInternalServerError)
 				return
@@ -55,13 +55,13 @@ func Update(store workflow.RecordStore) http.HandlerFunc {
 				return
 			}
 		case "cancel":
-			err = ctr.Cancel(r.Context())
+			err = ctr.Cancel(r.Context(), "")
 			if err != nil {
 				http.Error(w, "failed to cancel record", http.StatusInternalServerError)
 				return
 			}
 		case "delete":
-			err = ctr.DeleteData(r.Context())
+			err = ctr.DeleteData(r.Context(), "")
 			if err != nil {
 				http.Error(w, "failed to delete data of record", http.StatusInternalServerError)
 				return

--- a/adapters/webui/internal/api/update_test.go
+++ b/adapters/webui/internal/api/update_test.go
@@ -176,6 +176,7 @@ func TestUpdateHandler(t *testing.T) {
 
 				// No need to compare objects
 				expected.Object = actual.Object
+				expected.Meta.Version = 1
 				require.Equal(t, expected, *actual)
 			}
 		})

--- a/adapters/webui/internal/frontend/home.html
+++ b/adapters/webui/internal/frontend/home.html
@@ -92,6 +92,7 @@
                     <th class="py-3 px-4 text-center font-medium text-sm">Foreign ID</th>
                     <th class="py-3 px-4 text-center font-medium text-sm">Run ID</th>
                     <th class="py-3 px-4 text-center font-medium text-sm">Run State</th>
+                    <th class="py-3 px-4 text-center font-medium text-sm">Version</th>
                     <th class="py-3 px-4 text-center font-medium text-sm">Status</th>
                     <th class="py-3 px-4 text-center font-medium text-sm">Duration</th>
                     <th class="py-3 px-4 text-center font-medium text-sm">Object</th>
@@ -106,7 +107,6 @@
     </div>
     <div id="jsonModal" class="fixed inset-0 bg-gray-800 bg-opacity-50 flex items-center justify-center hidden">
         <div class="bg-white p-6 rounded-lg shadow-lg min-h-[50vh] min-w-[50vw] overflow-auto">
-            <h2 class="text-xl font-semibold mb-4">Object</h2>
             <div id="jsonContainer" class="bg-gray-100 p-4 rounded text-sm"></div>
             <button onclick="closeModal()" class="bg-red-500 text-white px-4 py-2 mt-4 rounded">Close</button>
         </div>

--- a/adapters/webui/ui.go
+++ b/adapters/webui/ui.go
@@ -20,8 +20,8 @@ type (
 	Paths               = frontend.Paths
 )
 
-func ListHandlerFunc(store workflow.RecordStore, stringer Stringer) http.HandlerFunc {
-	return api.List(store.List, stringer)
+func ListHandlerFunc(store workflow.RecordStore) http.HandlerFunc {
+	return api.List(store.List)
 }
 
 func ObjectDataHandlerFunc(store workflow.RecordStore) http.HandlerFunc {

--- a/event.go
+++ b/event.go
@@ -99,6 +99,7 @@ func MakeOutboxEventData(record Record) (OutboxEventData, error) {
 	headers[string(HeaderTopic)] = topic
 	headers[string(HeaderRunID)] = record.RunID
 	headers[string(HeaderRunState)] = strconv.FormatInt(int64(record.RunState), 10)
+	headers[string(HeaderRecordVersion)] = strconv.FormatInt(int64(record.Meta.Version), 10)
 
 	r := outboxpb.OutboxRecord{
 		RunId:   record.RunID,

--- a/eventstreamer.go
+++ b/eventstreamer.go
@@ -39,6 +39,7 @@ const (
 	HeaderTopic         Header = "topic"
 	HeaderRunID         Header = "run_id"
 	HeaderRunState      Header = "run_state"
+	HeaderRecordVersion Header = "record_version"
 	HeaderConnectorData Header = "connector_data"
 )
 

--- a/hook_test.go
+++ b/hook_test.go
@@ -19,7 +19,7 @@ func TestWorkflow_OnPauseHook(t *testing.T) {
 
 	wf := setupHookTest(t, func(b *workflow.Builder[MyType, status]) {
 		b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[MyType, status]) (status, error) {
-			return r.Pause(ctx)
+			return r.Pause(ctx, "Test pausing")
 		}, StatusMiddle)
 
 		b.OnPause(func(ctx context.Context, record *workflow.TypedRecord[MyType, status]) error {
@@ -41,7 +41,7 @@ func TestWorkflow_OnCancelHook(t *testing.T) {
 
 	wf := setupHookTest(t, func(b *workflow.Builder[MyType, status]) {
 		b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[MyType, status]) (status, error) {
-			return r.Cancel(ctx)
+			return r.Cancel(ctx, "Test cancel")
 		}, StatusMiddle)
 
 		b.OnCancel(func(ctx context.Context, record *workflow.TypedRecord[MyType, status]) error {

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -1,0 +1,46 @@
+package stack
+
+import (
+	"runtime"
+	"strings"
+)
+
+// Trace returns a stack trace of the external caller. Depth refers to the depth inside workflow that Trace is being
+// called from. So if the exported function in Workflow that is being called is 2 calls up then depth should be 2
+// to trum
+func Trace(depth int) string {
+	// Capture at most 4KB of the stack trace
+	stack := make([]byte, 4096)
+	n := runtime.Stack(stack, false)
+
+	// Convert the stack trace to a string and split it by newlines.
+	trace := string(stack[:n])
+	lines := strings.Split(trace, "\n")
+
+	var (
+		stackTrace     string
+		remainingDepth = depth + 1 // Add one to remove the stack entry of "/internal/stack/stack.go"
+	)
+	for _, line := range lines {
+		if strings.Contains(line, "github.com/luno/workflow") {
+			continue
+		}
+
+		if strings.Contains(line, "goroutine") {
+			continue
+		}
+
+		if !strings.Contains(line, "/") {
+			continue
+		}
+
+		if remainingDepth != 0 {
+			remainingDepth--
+			continue
+		}
+
+		stackTrace += line + "\n"
+	}
+
+	return stackTrace
+}

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -6,8 +6,7 @@ import (
 )
 
 // Trace returns a stack trace of the external caller. Depth refers to the depth inside workflow that Trace is being
-// called from. So if the exported function in Workflow that is being called is 2 calls up then depth should be 2
-// to trum
+// called from. So if the exported function in Workflow that is being called is 2 calls up then depth should be 2.
 func Trace(depth int) string {
 	// Capture at most 4KB of the stack trace
 	stack := make([]byte, 4096)

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -16,10 +16,7 @@ func Trace() string {
 	trace := string(stack[:n])
 	lines := strings.Split(trace, "\n")
 
-	var (
-		stackTrace     string
-		remainingDepth = 1 // Add one to remove the stack entry of "/internal/stack/stack.go"
-	)
+	var stackTrace string
 	for _, line := range lines {
 		if strings.Contains(line, "github.com/luno/workflow") {
 			continue
@@ -30,11 +27,6 @@ func Trace() string {
 		}
 
 		if !strings.Contains(line, "/") {
-			continue
-		}
-
-		if remainingDepth != 0 {
-			remainingDepth--
 			continue
 		}
 

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -6,8 +6,8 @@ import (
 )
 
 // Trace returns a stack trace of the external caller. Depth refers to the depth inside workflow that Trace is being
-// called from. So if the exported function in Workflow that is being called is 2 calls up then depth should be 2.
-func Trace(depth int) string {
+// called from.
+func Trace() string {
 	// Capture at most 4KB of the stack trace
 	stack := make([]byte, 4096)
 	n := runtime.Stack(stack, false)
@@ -18,7 +18,7 @@ func Trace(depth int) string {
 
 	var (
 		stackTrace     string
-		remainingDepth = depth + 1 // Add one to remove the stack entry of "/internal/stack/stack.go"
+		remainingDepth = 1 // Add one to remove the stack entry of "/internal/stack/stack.go"
 	)
 	for _, line := range lines {
 		if strings.Contains(line, "github.com/luno/workflow") {

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestTrace(t *testing.T) {
 	t.Run("Basic 0 depth", func(t *testing.T) {
-		trace := stack.Trace(0)
+		trace := stack.Trace()
 		require.Contains(t, trace, "stack_test.go")
 		require.Contains(t, trace, "/internal/stack/stack_test.go")
 	})
@@ -18,7 +18,7 @@ func TestTrace(t *testing.T) {
 	t.Run("Exclude internal 3 deep stack", func(t *testing.T) {
 		var trace string
 		grandchild := func() {
-			trace = stack.Trace(3)
+			trace = stack.Trace()
 		}
 		child := func() {
 			grandchild()
@@ -31,6 +31,16 @@ func TestTrace(t *testing.T) {
 		}
 
 		external()
-		t.Log(trace)
+
+		shouldContain := []string{
+			"stack_test.go:21",
+			"stack_test.go:24",
+			"stack_test.go:27",
+			"stack_test.go:30",
+			"stack_test.go:33",
+		}
+		for _, line := range shouldContain {
+			require.Contains(t, trace, line)
+		}
 	})
 }

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -1,0 +1,36 @@
+package stack_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/luno/workflow/internal/stack"
+)
+
+func TestTrace(t *testing.T) {
+	t.Run("Basic 0 depth", func(t *testing.T) {
+		trace := stack.Trace(0)
+		require.Contains(t, trace, "stack_test.go")
+		require.Contains(t, trace, "/internal/stack/stack_test.go")
+	})
+
+	t.Run("Exclude internal 3 deep stack", func(t *testing.T) {
+		var trace string
+		grandchild := func() {
+			trace = stack.Trace(3)
+		}
+		child := func() {
+			grandchild()
+		}
+		parent := func() {
+			child()
+		}
+		external := func() {
+			parent()
+		}
+
+		external()
+		t.Log(trace)
+	})
+}

--- a/pause.go
+++ b/pause.go
@@ -31,7 +31,7 @@ func maybePause[Type any, Status StatusType](
 		return false, nil
 	}
 
-	_, err = run.Pause(ctx)
+	_, err = run.Pause(ctx, "max error retry threshold hit - automatically paused")
 	if err != nil {
 		return false, err
 	}

--- a/record.go
+++ b/record.go
@@ -3,16 +3,77 @@ package workflow
 import "time"
 
 // Record is the cornerstone of Workflow. Record must always be wire compatible with no generics as it's intended
-// purpose is to be the stored structure of a Run.
+// purpose is to be the persisted data structure of a Run.
 type Record struct {
+	// WorkflowName is the name of the workflow associated with this record. It helps to identify which workflow
+	// this record belongs to.
 	WorkflowName string
-	ForeignID    string
-	RunID        string
-	RunState     RunState
-	Status       int
-	Object       []byte
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+
+	// ForeignID is an external identifier for this record, often used to associate it with an external system or
+	// resource. This can be useful for linking data across systems.
+	ForeignID string
+
+	// RunID uniquely identifies the specific execution or instance of the workflow Run and is a UUID v4.
+	// It allows tracking of different runs of the same workflow and foreign id.
+	RunID string
+
+	// RunState represents the current state of the workflow Run (e.g., running, paused, completed).
+	// This field is important for understanding the lifecycle status of the run.
+	RunState RunState
+
+	// Status is an integer representing the numerical status code of the record.
+	// Terminal, or end, statuses are written as past tense as they are fact and cannot change but present continuous
+	// tense is used to describe the current process taking place (e.g. submitting, creating, storing)
+	Status int
+
+	// Object contains the actual data associated with the workflow Run, serialized as bytes.
+	// This could be any kind of structured data related to the workflow execution. To unmarshal this data Unmarshal
+	// must be used to do so and the type matches the generic type called "Type" provided to the workflow builder
+	// ( e.g. NewBuilder[Type any, ...])
+	Object []byte
+
+	// CreatedAt is the timestamp when the record was created, providing context on when the workflow Run was initiated.
+	CreatedAt time.Time
+
+	// UpdatedAt is the timestamp when the record was last updated. This helps track the most recent changes made to
+	// the record.
+	UpdatedAt time.Time
+
+	// Meta stores any additional metadata related to the record, such as human-readable reasons for the RunState
+	// or other contextual information that can assist with debugging or auditing.
+	Meta Meta
+}
+
+// Meta provides contextual information such as the string value of the Status at the given time of the last update
+// and the reason the RunState is it's current value is uncommon or the need to know enables debugging. This is
+// particularly useful when accessing the data of the record without the ability to cast it to a TypedRecord which is
+// often the case when debugging the data via the RecordStore.
+type Meta struct {
+	// RunStateReason provides a human-readable explanation for the current run state.
+	// This field helps to understand the cause behind the current state of the run, such as "Paused", "Canceled", or "Deleted".
+	// For instance, calling functions like Pause, Cancel, or DeleteData will update this field with a descriptive reason
+	// that explains why the run is in its current state, making it easier to understand the context behind the state transition.
+	RunStateReason string
+
+	// StatusDescription provides a human-readable version of the Status field (int).
+	// It allows for better understanding and readability of the status at the time of the computation, especially when reviewing
+	// historical data. While the `Status` field stores the status as an integer, `StatusDescription` maps that status to a
+	// corresponding string description, making it easier to interpret the status without needing to refer to status codes.
+	StatusDescription string
+
+	// Version defines the version of the record. The Workflow increments this value before storing it in the
+	// RecordStore and uses it for data validation when consuming an event. The event will contain a matching version,
+	// ensuring that the event and the record from the RecordStore align, and that the data is not stale. This versioning
+	// mechanism also helps address replication lag issues, particularly in systems using databases that experience
+	// replication delays between replicas. By matching the version, Workflow ensures that the version collected from
+	// the reader is indeed the version expected. If the version in the RecordStore is greater than the event can be
+	// ignored as it has already been processed.
+	Version uint
+
+	// TraceOrigin contains a trace of the origin or source where the workflow Run was triggered from.
+	// It provides a line trace or path that helps track where the execution was initiated,
+	// offering context for debugging or auditing purposes by capturing the origin of the workflow trigger.
+	TraceOrigin string
 }
 
 // TypedRecord differs from Record in that it contains a Typed Object and Typed Status

--- a/run.go
+++ b/run.go
@@ -18,8 +18,8 @@ type Run[Type any, Status StatusType] struct {
 // Pause is intended to be used inside a workflow process where (Status, error) are the return signature. This allows
 // the user to simply type "return r.Pause(ctx)" to pause a record from inside a workflow which results in the record
 // being temporarily left alone and will not be processed until it is resumed.
-func (r *Run[Type, Status]) Pause(ctx context.Context) (Status, error) {
-	err := r.controller.Pause(ctx)
+func (r *Run[Type, Status]) Pause(ctx context.Context, reason string) (Status, error) {
+	err := r.controller.Pause(ctx, reason)
 	if err != nil {
 		return 0, err
 	}
@@ -35,8 +35,8 @@ func (r *Run[Type, Status]) Skip() (Status, error) {
 // Cancel is intended to be used inside a workflow process where (Status, error) are the return signature. This allows
 // the user to simply type "return r.Cancel(ctx)" to cancel a record from inside a workflow which results in the record
 // being permanently left alone and will not be processed.
-func (r *Run[Type, Status]) Cancel(ctx context.Context) (Status, error) {
-	err := r.controller.Cancel(ctx)
+func (r *Run[Type, Status]) Cancel(ctx context.Context, reason string) (Status, error) {
+	err := r.controller.Cancel(ctx, reason)
 	if err != nil {
 		return 0, err
 	}

--- a/run_test.go
+++ b/run_test.go
@@ -13,11 +13,11 @@ func TestNewTestingRun(t *testing.T) {
 	r := workflow.NewTestingRun[string, status](t, workflow.Record{}, "test")
 	ctx := context.Background()
 
-	pauseStatus, err := r.Pause(ctx)
+	pauseStatus, err := r.Pause(ctx, "")
 	require.Nil(t, err)
 	require.Equal(t, status(workflow.SkipTypeRunStateUpdate), pauseStatus)
 
-	cancelStatus, err := r.Cancel(ctx)
+	cancelStatus, err := r.Cancel(ctx, "")
 	require.Nil(t, err)
 	require.Equal(t, status(workflow.SkipTypeRunStateUpdate), cancelStatus)
 }
@@ -29,5 +29,4 @@ func TestNewTestingRun_requiresTestingParam(t *testing.T) {
 			_ = workflow.NewTestingRun[string, status](nil, workflow.Record{}, "test")
 		},
 	)
-
 }

--- a/runstate_internal_test.go
+++ b/runstate_internal_test.go
@@ -11,16 +11,16 @@ func TestNoopRunStateController(t *testing.T) {
 	ctrl := testingRunStateController{}
 
 	ctx := context.Background()
-	err := ctrl.Pause(ctx)
+	err := ctrl.Pause(ctx, "")
 	require.Nil(t, err)
 
 	err = ctrl.Resume(ctx)
 	require.Nil(t, err)
 
-	err = ctrl.Cancel(ctx)
+	err = ctrl.Cancel(ctx, "")
 	require.Nil(t, err)
 
-	err = ctrl.DeleteData(ctx)
+	err = ctrl.DeleteData(ctx, "")
 	require.Nil(t, err)
 }
 
@@ -333,7 +333,7 @@ func TestRunStateControllerTransitions(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			err := ctrl.update(ctx, tc.to)
+			err := ctrl.update(ctx, tc.to, "")
 			require.Equal(t, tc.valid, err == nil)
 		})
 	}

--- a/testing.go
+++ b/testing.go
@@ -256,7 +256,7 @@ type testingRunStateController struct {
 	deleteData func(ctx context.Context) error
 }
 
-func (c *testingRunStateController) Pause(ctx context.Context) error {
+func (c *testingRunStateController) Pause(ctx context.Context, reason string) error {
 	if c.pause == nil {
 		return nil
 	}
@@ -264,7 +264,7 @@ func (c *testingRunStateController) Pause(ctx context.Context) error {
 	return c.pause(ctx)
 }
 
-func (c *testingRunStateController) Cancel(ctx context.Context) error {
+func (c *testingRunStateController) Cancel(ctx context.Context, reason string) error {
 	if c.cancel == nil {
 		return nil
 	}
@@ -280,7 +280,7 @@ func (c *testingRunStateController) Resume(ctx context.Context) error {
 	return c.resume(ctx)
 }
 
-func (c *testingRunStateController) DeleteData(ctx context.Context) error {
+func (c *testingRunStateController) DeleteData(ctx context.Context, reason string) error {
 	if c.deleteData == nil {
 		return nil
 	}

--- a/testing_test.go
+++ b/testing_test.go
@@ -40,7 +40,7 @@ func TestTriggerCallbackOn_validation(t *testing.T) {
 			func() {
 				b := workflow.NewBuilder[string, status]("test")
 				b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[string, status]) (status, error) {
-					return r.Cancel(ctx)
+					return 0, nil
 				}, StatusEnd)
 
 				w := b.Build(
@@ -69,7 +69,7 @@ func TestAwaitTimeoutInsert_validation(t *testing.T) {
 			func() {
 				b := workflow.NewBuilder[string, status]("test")
 				b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[string, status]) (status, error) {
-					return r.Cancel(ctx)
+					return 0, nil
 				}, StatusEnd)
 
 				wf := b.Build(
@@ -131,7 +131,7 @@ func TestRequire_validation(t *testing.T) {
 			func() {
 				b := workflow.NewBuilder[string, status]("test")
 				b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[string, status]) (status, error) {
-					return r.Cancel(ctx)
+					return 0, nil
 				}, StatusEnd)
 
 				wf := b.Build(

--- a/trigger.go
+++ b/trigger.go
@@ -76,7 +76,7 @@ func trigger[Type any, Status StatusType](
 
 	meta := Meta{
 		StatusDescription: util.CamelCaseToSpacing(startingStatus.String()),
-		TraceOrigin:       stack.Trace(1),
+		TraceOrigin:       stack.Trace(),
 	}
 
 	uid, err := uuid.NewUUID()

--- a/update.go
+++ b/update.go
@@ -97,7 +97,7 @@ func updateRecord(ctx context.Context, store storeFunc, record *Record, previous
 		Inc()
 
 	// Increment the version by 1.
-	record.Meta.Version += 1
+	record.Meta.Version++
 
 	return store(ctx, record)
 }

--- a/update.go
+++ b/update.go
@@ -17,7 +17,12 @@ type (
 	updater[Type any, Status StatusType] func(ctx context.Context, current Status, next Status, run *Run[Type, Status]) error
 )
 
-func newUpdater[Type any, Status StatusType](lookup lookupFunc, store storeFunc, graph *graph.Graph, clock clock.Clock) updater[Type, Status] {
+func newUpdater[Type any, Status StatusType](
+	lookup lookupFunc,
+	store storeFunc,
+	graph *graph.Graph,
+	clock clock.Clock,
+) updater[Type, Status] {
 	return func(ctx context.Context, current Status, next Status, record *Run[Type, Status]) error {
 		object, err := Marshal(&record.Object)
 		if err != nil {
@@ -39,6 +44,7 @@ func newUpdater[Type any, Status StatusType](lookup lookupFunc, store storeFunc,
 			Object:       object,
 			CreatedAt:    record.CreatedAt,
 			UpdatedAt:    clock.Now(),
+			Meta:         record.Meta,
 		}
 
 		latest, err := lookup(ctx, updatedRecord.RunID)
@@ -57,10 +63,7 @@ func newUpdater[Type any, Status StatusType](lookup lookupFunc, store storeFunc,
 			return err
 		}
 
-		// Push run state changes for observability
-		metrics.RunStateChanges.WithLabelValues(record.WorkflowName, record.RunState.String(), updatedRecord.RunState.String()).Inc()
-
-		return store(ctx, updatedRecord)
+		return updateRecord(ctx, store, updatedRecord, record.RunState)
 	}
 }
 
@@ -90,7 +93,11 @@ func validateTransition[Status StatusType](current, next Status, graph *graph.Gr
 
 func updateRecord(ctx context.Context, store storeFunc, record *Record, previousRunState RunState) error {
 	// Push run state changes for observability
-	metrics.RunStateChanges.WithLabelValues(record.WorkflowName, previousRunState.String(), record.RunState.String()).Inc()
+	metrics.RunStateChanges.WithLabelValues(record.WorkflowName, previousRunState.String(), record.RunState.String()).
+		Inc()
+
+	// Increment the version by 1.
+	record.Meta.Version += 1
 
 	return store(ctx, record)
 }


### PR DESCRIPTION
The following have been added in a new type called `workflow.Meta` and will require a small migration process before upgrading to the version that contains these changes. This is only acceptable as workflow is pre-V1. These are some very old ideas that have numerously come back over and over again as invaluable to a production system. I dont like extending workflow but these are some ideas I believe are intrinsic to having a solution that provides the developers the correct tools to debug issues. One fundamental change is that of the addition of versioning.

Workflow is currently exposed to an issue where it will discard an event if the record store is lagging behind the event streamer. Due to the outbox pattern being implemented this meant it was unlikely happening but the reality is that it's a risk to the systems guaranteed once delivery and processing and should be mitigated.

Here are the fields that are found in Meta and their corresponding purposes:

Version: Ensures data consistency by validating that the record's version matches the event version, preventing issues with stale or out-of-order data that can take place when reading from a replica that is lagging behind the origin of the event.

RunStateReason: Human-readable explanation for the current run state, aiding in debugging by providing context behind state transitions (e.g., "Paused", "Canceled").

StatusDescription: A string representation of the Status field, making it easier to interpret status values (e.g., "In Progress", "Completed") without referencing status codes. Camel case string values are normalised to have spaces again for improved readability

TraceOrigin: Captures the origin or source of the workflow trigger, offering traceability for debugging and auditing purposes.
