### PR TITLE
adapters/sqlstore: Handle null meta for migrating users

### DIFF
--- a/adapters/sqlstore/schema.sql
+++ b/adapters/sqlstore/schema.sql
@@ -8,7 +8,7 @@ create table workflow_records (
     object                 longblob not null,
     created_at             datetime(3) not null,
     updated_at             datetime(3) not null,
-    meta                   blob not null,
+    meta                   blob,
 
     primary key(run_id),
 

--- a/adapters/sqlstore/util.go
+++ b/adapters/sqlstore/util.go
@@ -180,9 +180,11 @@ func recordScan(row row) (*workflow.Record, error) {
 		return nil, errors.Wrap(err, "recordScan")
 	}
 
-	err = json.Unmarshal(meta, &r.Meta)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to unmarshal meta for record")
+	if len(meta) > 0 {
+		err = json.Unmarshal(meta, &r.Meta)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to unmarshal meta for record")
+		}
 	}
 
 	return &r, nil

--- a/adapters/sqlstore/util_test.go
+++ b/adapters/sqlstore/util_test.go
@@ -19,7 +19,7 @@ var migrations = []string{
 		object                 longblob not null,
 		created_at             datetime(3) not null,
 		updated_at             datetime(3) not null,
-		meta                   blob not null,
+		meta                   blob,
 	
 		primary key(run_id),
 	


### PR DESCRIPTION
Allows for null meta which is needed for anyone migrating to the newest version that writes meta.
