### PR TITLE
renovate: Add post-update command to tidy modules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,11 @@
   ],
   "additionalReviewers": [
     "andrewwormald"
-  ]
+  ],
+  "postUpgradeTasks": {
+    "commands": [
+      "find . -name \"go.mod\" -type f -exec dirname {} \\; | while read dir; do echo \"Running go mod tidy in $dir\"; cd \"$dir\" && go mod tidy && cd - > /dev/null; done"
+    ],
+    "fileFilters": ["**/go.mod", "**/go.sum"]
+  }
 }


### PR DESCRIPTION
### Changed
- Renovate config to `go mod tidy` recursively after completing updates (so CI doesn't fail)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Automated cleanup of Go module dependencies will now occur after dependency upgrades, ensuring all relevant directories are tidied when Go-related files are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->