### PR TITLE
workflow/meta: Correctly update status description

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -71,6 +71,7 @@ func runDelete(
 			store,
 			record,
 			RunStateRequestedDataDeleted,
+			record.Meta.StatusDescription,
 		)
 	}
 }

--- a/runstate.go
+++ b/runstate.go
@@ -126,7 +126,7 @@ func (rsc *runStateControllerImpl) update(ctx context.Context, rs RunState, reas
 	previousRunState := rsc.record.RunState
 	rsc.record.RunState = rs
 	rsc.record.Meta.RunStateReason = reason
-	return updateRecord(ctx, rsc.store, rsc.record, previousRunState)
+	return updateRecord(ctx, rsc.store, rsc.record, previousRunState, rsc.record.Meta.StatusDescription)
 }
 
 var runStateTransitions = map[RunState]map[RunState]bool{

--- a/trigger.go
+++ b/trigger.go
@@ -97,7 +97,7 @@ func trigger[Type any, Status StatusType](
 		Meta:         meta,
 	}
 
-	err = updateRecord(ctx, store, wr, RunStateUnknown)
+	err = updateRecord(ctx, store, wr, RunStateUnknown, startingStatus.String())
 	if err != nil {
 		return "", err
 	}

--- a/update.go
+++ b/update.go
@@ -63,7 +63,7 @@ func newUpdater[Type any, Status StatusType](
 			return err
 		}
 
-		return updateRecord(ctx, store, updatedRecord, record.RunState)
+		return updateRecord(ctx, store, updatedRecord, record.RunState, next.String())
 	}
 }
 
@@ -91,11 +91,18 @@ func validateTransition[Status StatusType](current, next Status, graph *graph.Gr
 	return nil
 }
 
-func updateRecord(ctx context.Context, store storeFunc, record *Record, previousRunState RunState) error {
+func updateRecord(
+	ctx context.Context,
+	store storeFunc,
+	record *Record,
+	previousRunState RunState,
+	statusDescription string,
+) error {
 	// Push run state changes for observability
 	metrics.RunStateChanges.WithLabelValues(record.WorkflowName, previousRunState.String(), record.RunState.String()).
 		Inc()
 
+	record.Meta.StatusDescription = statusDescription
 	// Increment the version by 1.
 	record.Meta.Version++
 

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -151,6 +151,7 @@ func TestWorkflowAcceptanceTest(t *testing.T) {
 	r, err := recordStore.Latest(ctx, wf.Name(), fid)
 	require.Nil(t, err)
 	require.Equal(t, int(expectedFinalStatus), r.Status)
+	require.Equal(t, "Completed", r.Meta.StatusDescription)
 
 	var actual MyType
 	err = workflow.Unmarshal(r.Object, &actual)


### PR DESCRIPTION
Fix: Correctly update status description in workflow meta

This merge request ensures that the `StatusDescription` field in the workflow metadata is correctly updated during state transitions.

Previously, the `StatusDescription` was not consistently updated, leading to a stale description of the status.

The changes include:

- Modifying the `updateRecord` function to accept a `statusDescription` parameter.
- Updating callers of `updateRecord` to provide the current status description.
- Adjusting the workflow acceptance test to verify the `StatusDescription`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling and storage of status descriptions for workflow records, ensuring more accurate status information is maintained.
- **Tests**
	- Enhanced workflow acceptance tests to verify that the status description is correctly set upon workflow completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->