### PR TITLE
workflow: Update to Go v1.24.2

### DIFF
--- a/_examples/callback/callback_test.go
+++ b/_examples/callback/callback_test.go
@@ -1,7 +1,6 @@
 package callback_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/luno/workflow"
@@ -21,7 +20,7 @@ func TestCallbackWorkflow(t *testing.T) {
 	})
 	t.Cleanup(wf.Stop)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	wf.Run(ctx)
 
 	foreignID := "andrew"

--- a/_examples/callback/go.mod
+++ b/_examples/callback/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/_examples/callback
 
-go 1.23.2
+go 1.24.2
 
 replace github.com/luno/workflow => ../..
 

--- a/_examples/connector/connector_test.go
+++ b/_examples/connector/connector_test.go
@@ -1,7 +1,6 @@
 package connector_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -34,7 +33,7 @@ func TestConnectStreamParallelConsumer(t *testing.T) {
 		Connector:     memstreamer.NewConnector(events),
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	w.Run(ctx)
 	t.Cleanup(w.Stop)
 

--- a/_examples/connector/go.mod
+++ b/_examples/connector/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/_examples/connector
 
-go 1.23.2
+go 1.24.2
 
 replace github.com/luno/workflow => ../..
 

--- a/_examples/gettingstarted/gettingstarted_test.go
+++ b/_examples/gettingstarted/gettingstarted_test.go
@@ -1,7 +1,6 @@
 package gettingstarted_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/luno/workflow"
@@ -23,7 +22,7 @@ func TestWorkflow(t *testing.T) {
 	})
 	t.Cleanup(wf.Stop)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	wf.Run(ctx)
 
 	foreignID := "82347982374982374"

--- a/_examples/gettingstarted/go.mod
+++ b/_examples/gettingstarted/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/_examples/gettingstarted
 
-go 1.23.2
+go 1.24.2
 
 replace github.com/luno/workflow => ../..
 

--- a/_examples/schedule/go.mod
+++ b/_examples/schedule/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/_examples/schedule
 
-go 1.23.2
+go 1.24.2
 
 replace github.com/luno/workflow => ../..
 

--- a/_examples/schedule/schedule_test.go
+++ b/_examples/schedule/schedule_test.go
@@ -1,7 +1,6 @@
 package schedule_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -30,7 +29,7 @@ func TestExampleWorkflow(t *testing.T) {
 	})
 	t.Cleanup(wf.Stop)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	wf.Run(ctx)
 
 	foreignID := "hourly-run"

--- a/_examples/timeout/go.mod
+++ b/_examples/timeout/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/_examples/timeout
 
-go 1.23.2
+go 1.24.2
 
 replace github.com/luno/workflow => ../..
 

--- a/_examples/timeout/timeout_test.go
+++ b/_examples/timeout/timeout_test.go
@@ -1,7 +1,6 @@
 package timeout_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -28,7 +27,7 @@ func TestTimeoutWorkflow(t *testing.T) {
 	})
 	t.Cleanup(wf.Stop)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	wf.Run(ctx)
 
 	foreignID := "andrew"

--- a/_examples/webui/go.mod
+++ b/_examples/webui/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/_examples/webui
 
-go 1.23.2
+go 1.24.2
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/jlog/go.mod
+++ b/adapters/jlog/go.mod
@@ -1,8 +1,6 @@
 module github.com/luno/workflow/adapters/jlog
 
-go 1.23.4
-
-toolchain go1.23.5
+go 1.24.2
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/jlog/jlog_test.go
+++ b/adapters/jlog/jlog_test.go
@@ -2,7 +2,6 @@ package jlog_test
 
 import (
 	"bytes"
-	"context"
 	"strings"
 	"testing"
 
@@ -19,7 +18,7 @@ func TestDebug(t *testing.T) {
 	log.SetLoggerForTesting(t, jLogger)
 
 	logger := jlog.New()
-	ctx := context.Background()
+	ctx := t.Context()
 	logger.Debug(ctx, "test message", map[string]string{"testKey": "testValue"})
 
 	require.Equal(t, "D 00:00:00.000 g/l/w/a/jlog/jlog.go:19: test message[testkey=testValue]\n", buf.String())
@@ -31,7 +30,7 @@ func TestError(t *testing.T) {
 	log.SetLoggerForTesting(t, jLogger)
 
 	logger := jlog.New()
-	ctx := context.Background()
+	ctx := t.Context()
 	testErr := errors.New("test error")
 	logger.Error(ctx, testErr)
 

--- a/adapters/kafkastreamer/go.mod
+++ b/adapters/kafkastreamer/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/adapters/kafkastreamer
 
-go 1.23.2
+go 1.24.2
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/kafkastreamer/kafka_test.go
+++ b/adapters/kafkastreamer/kafka_test.go
@@ -1,7 +1,6 @@
 package kafkastreamer_test
 
 import (
-	"context"
 	"strconv"
 	"testing"
 
@@ -19,7 +18,7 @@ const brokerAddress = "localhost:9092"
 
 func TestStreamer(t *testing.T) {
 	adaptertest.RunEventStreamerTest(t, func() workflow.EventStreamer {
-		ctx := context.Background()
+		ctx := t.Context()
 
 		kafkaInstance, err := kafkacontainer.Run(ctx, "confluentinc/confluent-local:7.5.0", kafkacontainer.WithClusterID("kraftCluster"))
 		testcontainers.CleanupContainer(t, kafkaInstance)
@@ -33,7 +32,7 @@ func TestStreamer(t *testing.T) {
 }
 
 func TestConnector(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	topic := "connector-topic"
 	kafkaInstance, err := kafkacontainer.Run(ctx, "confluentinc/confluent-local:7.5.0", kafkacontainer.WithClusterID("kraftCluster"))
 	testcontainers.CleanupContainer(t, kafkaInstance)

--- a/adapters/reflexstreamer/connector_internal_test.go
+++ b/adapters/reflexstreamer/connector_internal_test.go
@@ -57,7 +57,7 @@ func TestConnectorErrHandling(t *testing.T) {
 			},
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		consumer, err := connector.Make(ctx, "")
 		jtest.RequireNil(t, err)
 
@@ -81,7 +81,7 @@ func TestConnectorErrHandling(t *testing.T) {
 			},
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		consumer, err := connector.Make(ctx, "")
 		jtest.RequireNil(t, err)
 
@@ -108,7 +108,7 @@ func TestConnectorErrHandling(t *testing.T) {
 			},
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		consumer, err := connector.Make(ctx, "")
 		jtest.RequireNil(t, err)
 
@@ -138,7 +138,7 @@ func TestConnectorErrHandling(t *testing.T) {
 			},
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		consumer, err := connector.Make(ctx, "")
 		jtest.RequireNil(t, err)
 
@@ -161,7 +161,7 @@ func TestConnectorErrHandling(t *testing.T) {
 			},
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		consumer, err := connector.Make(ctx, "")
 		jtest.RequireNil(t, err)
 
@@ -186,7 +186,7 @@ func TestConnectorErrHandling(t *testing.T) {
 			},
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		consumer, err := connector.Make(ctx, "")
 		jtest.RequireNil(t, err)
 
@@ -213,7 +213,7 @@ func TestConnectorErrHandling(t *testing.T) {
 			},
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		consumer, err := connector.Make(ctx, "")
 		jtest.RequireNil(t, err)
 

--- a/adapters/reflexstreamer/connector_test.go
+++ b/adapters/reflexstreamer/connector_test.go
@@ -1,7 +1,6 @@
 package reflexstreamer_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/luno/reflex/rsql"
@@ -17,7 +16,7 @@ func TestConnector(t *testing.T) {
 		dbc := ConnectForTesting(t)
 		cTable := rsql.NewCursorsTable("cursors")
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		for _, event := range seedEvents {
 			notify, err := eventsTable.Insert(ctx, dbc, event.ForeignID, reflexstreamer.EventType(1))

--- a/adapters/reflexstreamer/go.mod
+++ b/adapters/reflexstreamer/go.mod
@@ -1,8 +1,6 @@
 module github.com/luno/workflow/adapters/reflexstreamer
 
-go 1.23.4
-
-toolchain go1.23.5
+go 1.24.2
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/rinkrolescheduler/go.mod
+++ b/adapters/rinkrolescheduler/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/adapters/rinkrolescheduler
 
-go 1.23.2
+go 1.24.2
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/sqlstore/go.mod
+++ b/adapters/sqlstore/go.mod
@@ -1,8 +1,6 @@
 module github.com/luno/workflow/adapters/sqlstore
 
-go 1.23.4
-
-toolchain go1.23.5
+go 1.24.2
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/sqltimeout/go.mod
+++ b/adapters/sqltimeout/go.mod
@@ -1,8 +1,6 @@
 module github.com/luno/workflow/adapters/sqltimeout
 
-go 1.23.4
-
-toolchain go1.23.5
+go 1.24.2
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/webui/go.mod
+++ b/adapters/webui/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/adapters/webui
 
-go 1.23.2
+go 1.24.2
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/webui/internal/api/update_test.go
+++ b/adapters/webui/internal/api/update_test.go
@@ -2,7 +2,6 @@ package api_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -151,7 +150,7 @@ func TestUpdateHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			recordStore := memrecordstore.New()
 
-			ctx := context.Background()
+			ctx := t.Context()
 			for _, record := range tc.before {
 				err := recordStore.Store(ctx, &record)
 				require.NoError(t, err)

--- a/await_test.go
+++ b/await_test.go
@@ -29,7 +29,7 @@ func TestAwait(t *testing.T) {
 		memrolescheduler.New(),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	wf.Run(ctx)
 	t.Cleanup(wf.Stop)
 

--- a/callback_internal_test.go
+++ b/callback_internal_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestProcessCallback(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	w := &Workflow[string, testStatus]{
 		name:        "example",
 		ctx:         ctx,

--- a/delete_internal_test.go
+++ b/delete_internal_test.go
@@ -100,7 +100,7 @@ func TestRunDelete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			err := runDelete(
 				tc.storeFn,
 				tc.lookupFn,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow
 
-go 1.23.2
+go 1.24.2
 
 require (
 	github.com/google/uuid v1.6.0

--- a/hook_internal_test.go
+++ b/hook_internal_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Test_runHooks(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("Return non-nil error from lookup", func(t *testing.T) {
 		testErr := errors.New("test error")

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -2,7 +2,6 @@ package logger_test
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"testing"
 
@@ -15,7 +14,7 @@ func TestLoggerDebug(t *testing.T) {
 	var buf bytes.Buffer
 	log := logger.New(&buf)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	log.Debug(ctx, "test message", map[string]string{"key": "value"})
 
 	require.Contains(t, buf.String(), "\"level\":\"DEBUG\",\"msg\":\"test message\",\"meta\":{\"key\":\"value\"}")
@@ -25,7 +24,7 @@ func TestLogger_Error(t *testing.T) {
 	var buf bytes.Buffer
 	log := logger.New(&buf)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	log.Error(ctx, errors.New("test error"))
 
 	require.Contains(t, buf.String(), "\"level\":\"ERROR\",\"msg\":\"test error\"")

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -41,7 +41,7 @@ func runWorkflow(t *testing.T) *workflow.Workflow[string, status] {
 		workflow.WithClock(clock),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	uid, err := uuid.NewUUID()
 	require.Nil(t, err)
@@ -190,7 +190,7 @@ func TestMetricProcessIdleState(t *testing.T) {
 		workflow.WithClock(clock),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	wf.Run(ctx)
 	t.Cleanup(wf.Stop)
@@ -284,7 +284,7 @@ func TestMetricProcessErrors(t *testing.T) {
 		workflow.WithClock(clock),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	uid, err := uuid.NewUUID()
 	require.Nil(t, err)
@@ -344,7 +344,7 @@ func TestRunStateChanges(t *testing.T) {
 		),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	w.Run(ctx)
 	t.Cleanup(w.Stop)
 
@@ -376,7 +376,7 @@ func TestMetricProcessSkippedEvents(t *testing.T) {
 		memrolescheduler.New(),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	w.Run(ctx)
 	t.Cleanup(w.Stop)
 

--- a/pause_internal_test.go
+++ b/pause_internal_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_maybeAutoPause(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	counter := errorcounter.New()
 	testErr := errors.New("test error")
 	pauseErr := errors.New("pause error")
@@ -91,7 +91,7 @@ func Test_maybeAutoPause(t *testing.T) {
 
 func Test_retryPausedRecords(t *testing.T) {
 	t.Run("Golden path", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		clock := clock_testing.NewFakeClock(time.Now())
 		var calledUpdate bool
 		err := autoRetryConsumer(
@@ -114,7 +114,7 @@ func Test_retryPausedRecords(t *testing.T) {
 	})
 
 	t.Run("Return non-nil error on lookup", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		clock := clock_testing.NewFakeClock(time.Now())
 		testErr := errors.New("test error")
 		err := autoRetryConsumer(
@@ -129,7 +129,7 @@ func Test_retryPausedRecords(t *testing.T) {
 	})
 
 	t.Run("Return non-nil error from store func", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		clock := clock_testing.NewFakeClock(time.Now())
 		testErr := errors.New("test error")
 		err := autoRetryConsumer(
@@ -149,7 +149,7 @@ func Test_retryPausedRecords(t *testing.T) {
 	})
 
 	t.Run("Golden path - return nil with no update if before resume time", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		clock := clock_testing.NewFakeClock(time.Now())
 		var calledUpdate bool
 		err := autoRetryConsumer(
@@ -171,7 +171,7 @@ func Test_retryPausedRecords(t *testing.T) {
 	})
 
 	t.Run("Not in paused state", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		clock := clock_testing.NewFakeClock(time.Now())
 		var calledUpdate bool
 		err := autoRetryConsumer(

--- a/pause_test.go
+++ b/pause_test.go
@@ -41,7 +41,7 @@ func TestRetryOfPausedRecords(t *testing.T) {
 		workflow.WithPauseRetry(time.Millisecond*10),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	w.Run(ctx)
 	t.Cleanup(w.Stop)
 
@@ -74,7 +74,7 @@ func TestRetryOfPausedRecordsConfig(t *testing.T) {
 			workflow.DisablePauseRetry(),
 		)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		w.Run(ctx)
 		t.Cleanup(w.Stop)
 
@@ -90,7 +90,7 @@ func TestRetryOfPausedRecordsConfig(t *testing.T) {
 			memrolescheduler.New(),
 		)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		w.Run(ctx)
 		t.Cleanup(w.Stop)
 

--- a/run_test.go
+++ b/run_test.go
@@ -1,7 +1,6 @@
 package workflow_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,7 +10,7 @@ import (
 
 func TestNewTestingRun(t *testing.T) {
 	r := workflow.NewTestingRun[string, status](t, workflow.Record{}, "test")
-	ctx := context.Background()
+	ctx := t.Context()
 
 	pauseStatus, err := r.Pause(ctx, "")
 	require.Nil(t, err)

--- a/runstate_internal_test.go
+++ b/runstate_internal_test.go
@@ -10,7 +10,7 @@ import (
 func TestNoopRunStateController(t *testing.T) {
 	ctrl := testingRunStateController{}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := ctrl.Pause(ctx, "")
 	require.Nil(t, err)
 
@@ -332,7 +332,7 @@ func TestRunStateControllerTransitions(t *testing.T) {
 				},
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			err := ctrl.update(ctx, tc.to, "")
 			require.Equal(t, tc.valid, err == nil)
 		})

--- a/runstate_test.go
+++ b/runstate_test.go
@@ -63,7 +63,7 @@ func TestRunState(t *testing.T) {
 			recordStore := memrecordstore.New()
 			w := fn(recordStore)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			w.Run(ctx)
 			t.Cleanup(w.Stop)
 
@@ -123,7 +123,7 @@ func TestWorkflowRunStateController(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	workflowName := "test-workflow"
 	foreignID := "foreignID"
 	runID := "uuid"

--- a/state_test.go
+++ b/state_test.go
@@ -33,7 +33,7 @@ func TestInternalState(t *testing.T) {
 		return StatusCompleted, nil
 	}, StatusCompleted)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	b.AddConnector(
 		"consume-other-stream",

--- a/step_internal_test.go
+++ b/step_internal_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func Test_stepConsumer(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	counter := errorcounter.New()
 	processName := "processName"
 	testErr := errors.New("test error")

--- a/testing_test.go
+++ b/testing_test.go
@@ -175,7 +175,7 @@ func TestWaitFor(t *testing.T) {
 		memrolescheduler.New(),
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	t.Cleanup(cancel)
 	wf.Run(ctx)
 	t.Cleanup(wf.Stop)

--- a/testing_test.go
+++ b/testing_test.go
@@ -105,7 +105,7 @@ func TestRequire(t *testing.T) {
 		memrolescheduler.New(),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	wf.Run(ctx)
 	t.Cleanup(wf.Stop)
 

--- a/timeout_internal_test.go
+++ b/timeout_internal_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestProcessTimeout(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	counter := errorcounter.New()
 	processName := "processName"
 	testErr := errors.New("test error")

--- a/trigger_internal_test.go
+++ b/trigger_internal_test.go
@@ -17,14 +17,14 @@ func Test_trigger(t *testing.T) {
 	w := b.Build(nil, nil, nil, WithDebugMode())
 
 	t.Run("Expected non-nil error when Trigger called before Run()", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		_, err := trigger(ctx, w, nil, nil, "1")
 
 		require.Equal(t, "trigger failed: workflow is not running", err.Error())
 	})
 
 	t.Run("Expects ErrStatusProvidedNotConfigured when starting status is not configured", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		w.calledRun = true
 
 		_, err := trigger(ctx, w, nil, nil, "1", WithStartingPoint[string, testStatus](statusEnd))
@@ -32,7 +32,7 @@ func Test_trigger(t *testing.T) {
 	})
 
 	t.Run("Expects ErrWorkflowInProgress if a workflow run is already in progress", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		w.calledRun = true
 
 		_, err := trigger(ctx, w, func(ctx context.Context, workflowName, foreignID string) (*Record, error) {
@@ -47,7 +47,7 @@ func Test_trigger(t *testing.T) {
 	})
 
 	t.Run("Expects Meta to be correctly set", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		w.calledRun = true
 
 		_, err := trigger(ctx, w, func(ctx context.Context, workflowName, foreignID string) (*Record, error) {

--- a/update_internal_test.go
+++ b/update_internal_test.go
@@ -143,7 +143,7 @@ func TestUpdater(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			g := graph.New()
 			for _, transition := range tc.transitions {
 				g.AddTransition(transition.From, transition.To)

--- a/workflow_internal_test.go
+++ b/workflow_internal_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func Test_runOnce(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("Returns non-nil error (context.Canceled) when parent ctx is cancelled", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -546,7 +546,7 @@ func TestConnector(t *testing.T) {
 		memrolescheduler.New(),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	w.Run(ctx)
 	t.Cleanup(w.Stop)
 
@@ -593,7 +593,7 @@ func TestStepConsumerLag(t *testing.T) {
 		workflow.WithDebugMode(),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	wf.Run(ctx)
 	t.Cleanup(wf.Stop)
 


### PR DESCRIPTION
Upgrading core workflow and adapter modules to go 1.24.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Go version to 1.24.2 across all modules and example projects.

- **Tests**
  - Improved test reliability by switching context usage from a generic background context to the test framework's context in all test cases. This ensures better integration with test lifecycle management and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->