### PR TITLE
renovate: Revert postUpgradeCommand

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,14 +4,5 @@
   ],
   "additionalReviewers": [
     "andrewwormald"
-  ],
-  "postUpgradeTasks": {
-    "commands": [
-      "find . -name \"go.mod\" -type f -exec dirname {} \\; | while read dir; do echo \"Running go mod tidy in $dir\"; cd \"$dir\" && go mod tidy && cd - > /dev/null; done"
-    ],
-    "fileFilters": ["**/go.mod", "**/go.sum"]
-  },
-  "allowedCommands": [
-    "^find\\s\\.\\s-name.+go\\.mod.+go\\smod\\stidy"
   ]
 }


### PR DESCRIPTION
### Removed
- postUpgradeCommand - only works on self-hosted
- Hoping Renovate adds the `goModTidyAll` option mentioned soon https://github.com/renovatebot/renovate/issues/12999#issuecomment-1439752785, then we won't have to do this manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration by removing automated post-upgrade tasks and command permissions.
  - Only the designated reviewer remains specified in the settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->