### PR TITLE
filter: Add FilterTime

### DIFF
--- a/adapters/memrecordstore/memrecordstore.go
+++ b/adapters/memrecordstore/memrecordstore.go
@@ -225,6 +225,13 @@ func (s *Store) List(
 			continue
 		}
 
+		if filter.ByCreatedAtAfter().Enabled && !filter.ByCreatedAtAfter().Matches(record.CreatedAt) {
+			continue
+		}
+		if filter.ByCreatedAtBefore().Enabled && !filter.ByCreatedAtBefore().Matches(record.CreatedAt) {
+			continue
+		}
+
 		filteredStore[increment] = record
 		increment++
 	}

--- a/adapters/sqlstore/sqlstore.go
+++ b/adapters/sqlstore/sqlstore.go
@@ -3,6 +3,7 @@ package sqlstore
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -169,6 +170,14 @@ func (s *SQLStore) List(
 		}
 	}
 
+	if filter.ByCreatedAtAfter().Enabled {
+		wb.AddCondition("created_at", ">", filter.ByCreatedAtAfter().Value())
+	}
+
+	if filter.ByCreatedAtBefore().Enabled {
+		wb.AddCondition("created_at", "<", filter.ByCreatedAtBefore().Value())
+	}
+
 	if limit == 0 {
 		limit = defaultListLimit
 	}
@@ -193,6 +202,12 @@ type whereBuilder struct {
 
 func (fq *whereBuilder) WhereNotNull(field string) {
 	fq.conditions = append(fq.conditions, field+" is not null")
+}
+
+func (fq *whereBuilder) AddCondition(field string, comparison string, value any) {
+	condition := fmt.Sprintf("(%s %s?)", field, comparison)
+	fq.conditions = append(fq.conditions, condition)
+	fq.params = append(fq.params, value)
 }
 
 func (fq *whereBuilder) Where(field string, values ...string) {

--- a/filter_test.go
+++ b/filter_test.go
@@ -2,6 +2,7 @@ package workflow_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -45,9 +46,32 @@ func TestMakeFilter(t *testing.T) {
 		require.Equal(t, []string{"9", "12"}, filter.ByStatus().MultiValues(), "Expected status filter value to be {'9', '12'}")
 	})
 
+	t.Run("Filter by Created At After", func(t *testing.T) {
+		d := time.Date(2025, time.August, 1, 0, 0, 0, 0, time.UTC)
+		filter := workflow.MakeFilter(workflow.FilterByCreatedAtAfter(d))
+		require.True(t, filter.ByCreatedAtAfter().Enabled, "Expected created at after filter to be enabled")
+		require.Equal(t, d, filter.ByCreatedAtAfter().Value(), "Expected created at after filter value to be 1st of august 2025")
+	})
+
+	t.Run("Filter by Created At Before", func(t *testing.T) {
+		d := time.Date(2025, time.August, 1, 0, 0, 0, 0, time.UTC)
+		filter := workflow.MakeFilter(workflow.FilterByCreatedAtBefore(d))
+		require.True(t, filter.ByCreatedAtBefore().Enabled, "Expected created at before filter to be enabled")
+		require.Equal(t, d, filter.ByCreatedAtBefore().Value(), "Expected created at before filter value to be 1st of august 2025")
+	})
+
 	t.Run("Matches", func(t *testing.T) {
-		filter := workflow.MakeFilter(workflow.FilterByStatus(9))
+		t0 := time.Date(2025, time.August, 1, 0, 0, 0, 0, time.UTC)
+		t1 := time.Date(2025, time.August, 10, 0, 0, 0, 0, time.UTC)
+
+		filter := workflow.MakeFilter(workflow.FilterByStatus(9),
+			workflow.FilterByCreatedAtAfter(t0),
+			workflow.FilterByCreatedAtBefore(t1))
 		require.True(t, filter.ByStatus().Matches("9"))
+
+		match := time.Date(2025, time.August, 5, 0, 0, 0, 0, time.UTC)
+		require.True(t, filter.ByCreatedAtAfter().Matches(match))
+		require.True(t, filter.ByCreatedAtBefore().Matches(match))
 	})
 
 	t.Run("Matches - Multi", func(t *testing.T) {


### PR DESCRIPTION
Adding filter time function to retrieve specific records within time range

## For External Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/luno/.github/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] If it's a non-trivial change, I've linked a new or existing [issue](../issues) to this PR
- [x] I have performed a self-review of my code
- [x] Does your submission pass existing tests?
- [x] Have you written new tests for your new changes, if applicable?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added time-based filters to listings: filter records by Created At (After/Before) to narrow results by creation date.
  - Supported across in-memory and SQL backends, compatible with existing ordering and pagination.

- Tests
  - Added unit and integration tests covering Created At filters, including enablement, value handling, matching behaviour, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->