### PR TITLE
github/workflows: Use Go version in go.mod rather than static version

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: 'go.mod'
 
       - name: Generate Sonar Report
         run: go test -coverpkg=./... -coverprofile=coverage.out -json ./... > sonar-report.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
   core:
     strategy:
       matrix:
-        go: [ '1.23', '1' ]
+        go: [ '1.24', '1' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Vet Adapters
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
 
       - name: Vet Adapters
         run: |

--- a/adapters/memrolescheduler/memrolescheduler.go
+++ b/adapters/memrolescheduler/memrolescheduler.go
@@ -29,13 +29,10 @@ func (r *RoleScheduler) Await(ctx context.Context, role string) (context.Context
 	mu.Lock()
 
 	go func(role string) {
-		for {
-			<-ctx.Done()
-			r.mu.Lock()
-			r.roles[role].Unlock()
-			r.mu.Unlock()
-			return
-		}
+		<-ctx.Done()
+		r.mu.Lock()
+		r.roles[role].Unlock()
+		r.mu.Unlock()
 	}(role)
 
 	return ctx, cancel, nil


### PR DESCRIPTION
Update GitHub Actions workflow to use standardized Go versions ['1.24', '1'] in matrix and '1.24' for standalone usage instead of ['1.23', '1'] and '1.23'.

This change:
- Updates matrix strategy Go versions from ['1.23', '1'] to ['1.24', '1']
- Updates standalone Go version from '1.23' to '1.24'
- Uses Go 1.24 as the specific version for testing
- Uses Go '1' to always test against the latest stable version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * No user-facing changes in this release.

* Chores
  * Continuous integration now reads the Go version from the project configuration, avoiding hard-coded values.
  * Test matrix updated to include Go 1.24 for broader compatibility.

* Refactor
  * Simplified internal cancellation handling to reduce complexity without changing behaviour.

* Tests
  * Minor workflow formatting tidy-up with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->