### PR TITLE
outbox: Allow disabling of outbox

### DIFF
--- a/adapters/memrecordstore/memrecordstore_test.go
+++ b/adapters/memrecordstore/memrecordstore_test.go
@@ -1,15 +1,77 @@
 package memrecordstore_test
 
 import (
+	"context"
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/luno/workflow"
 	"github.com/luno/workflow/adapters/adaptertest"
 	"github.com/luno/workflow/adapters/memrecordstore"
+	"github.com/luno/workflow/adapters/memrolescheduler"
+	"github.com/luno/workflow/adapters/memstreamer"
+	"github.com/luno/workflow/internal/logger"
 )
 
 func TestStore(t *testing.T) {
 	adaptertest.RunRecordStoreTest(t, func() workflow.RecordStore {
 		return memrecordstore.New()
 	})
+}
+
+type status int
+
+const (
+	StatusUnknown status = 0
+	StatusStart   status = 1
+	StatusMiddle  status = 2
+	StatusEnd     status = 3
+)
+
+func (s status) String() string {
+	switch s {
+	case StatusStart:
+		return "Start"
+	case StatusMiddle:
+		return "Middle"
+	case StatusEnd:
+		return "End"
+	default:
+		return "Unknown"
+	}
+}
+
+func TestOutboxDisabled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+	})
+
+	eventStreamer := memstreamer.New()
+	recordStore := memrecordstore.New(memrecordstore.WithOutbox(ctx, eventStreamer, logger.New(os.Stdout)))
+
+	b := workflow.NewBuilder[string, status]("super fast workflow")
+	b.AddStep(StatusStart, func(ctx context.Context, r *workflow.Run[string, status]) (status, error) {
+		return StatusMiddle, nil
+	}, StatusMiddle)
+	b.AddStep(StatusMiddle, func(ctx context.Context, r *workflow.Run[string, status]) (status, error) {
+		return StatusEnd, nil
+	}, StatusEnd)
+	wf := b.Build(
+		eventStreamer,
+		recordStore,
+		memrolescheduler.New(),
+		workflow.WithoutOutbox(),
+	)
+
+	wf.Run(ctx)
+	t.Cleanup(wf.Stop)
+
+	runID, err := wf.Trigger(ctx, "some-related-id")
+	require.Nil(t, err)
+
+	_, err = wf.Await(ctx, "some-related-id", runID, StatusEnd)
+	require.Nil(t, err)
 }

--- a/adapters/memrecordstore/outbox.go
+++ b/adapters/memrecordstore/outbox.go
@@ -1,0 +1,114 @@
+package memrecordstore
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/luno/workflow"
+	"github.com/luno/workflow/internal/outboxpb"
+)
+
+type (
+	OutboxLister  func(limit int64) ([]workflow.OutboxEvent, error)
+	OutboxDeleter func(ctx context.Context, id string) error
+)
+
+func PurgeOutboxForever(
+	ctx context.Context,
+	list OutboxLister,
+	delete OutboxDeleter,
+	stream workflow.EventStreamer,
+	logger workflow.Logger,
+	pollingFrequency time.Duration,
+	lookupLimit int64,
+) error {
+	for ctx.Err() == nil {
+		err := purgeOutbox(
+			ctx,
+			list,
+			delete,
+			stream,
+			pollingFrequency,
+			lookupLimit,
+		)
+		if errors.Is(err, context.Canceled) {
+			return nil
+		} else if err != nil {
+			logger.Error(ctx, err)
+			time.Sleep(time.Second)
+			continue
+		}
+	}
+
+	return ctx.Err()
+}
+
+func purgeOutbox(
+	ctx context.Context,
+	list OutboxLister,
+	delete OutboxDeleter,
+	stream workflow.EventStreamer,
+	pollingFrequency time.Duration,
+	lookupLimit int64,
+) error {
+	events, err := list(lookupLimit)
+	if err != nil {
+		return err
+	}
+
+	if len(events) == 0 {
+		return wait(ctx, pollingFrequency)
+	}
+
+	// Send the events to the EventStreamer.
+	for _, e := range events {
+		var outboxRecord outboxpb.OutboxRecord
+		err := proto.Unmarshal(e.Data, &outboxRecord)
+		if err != nil {
+			return err
+		}
+
+		headers := make(map[workflow.Header]string)
+		for k, v := range outboxRecord.Headers {
+			headers[workflow.Header(k)] = v
+		}
+
+		foreignID := outboxRecord.RunId
+		eventType := int(outboxRecord.Type)
+
+		topic := headers[workflow.HeaderTopic]
+		producer, err := stream.NewSender(ctx, topic)
+		if err != nil {
+			return err
+		}
+
+		err = producer.Send(ctx, foreignID, eventType, headers)
+		if err != nil {
+			return err
+		}
+
+		err = delete(ctx, e.ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func wait(ctx context.Context, d time.Duration) error {
+	if d == 0 {
+		return nil
+	}
+
+	t := time.NewTimer(d)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/builder.go
+++ b/builder.go
@@ -292,6 +292,14 @@ func WithTimeoutStore(s TimeoutStore) BuildOption {
 	}
 }
 
+// WithoutOutbox disables the polling of the RecordStore outbox for pushing events to the provided EvetnStreamner
+// and allows for external submission of outbox messages to the EventStreamer.
+func WithoutOutbox() BuildOption {
+	return func(w *buildOptions) {
+		w.outboxConfig.disabled = true
+	}
+}
+
 // WithClock allows the configuring of workflow's use and access of time. Instead of using time.Now() and other
 // associated functionality from the time package a clock is used instead in order to make it testable.
 func WithClock(c clock.Clock) BuildOption {

--- a/outbox.go
+++ b/outbox.go
@@ -59,6 +59,7 @@ type outboxConfig struct {
 	pollingFrequency time.Duration
 	lagAlert         time.Duration
 	limit            int64
+	disabled         bool
 }
 
 func WithOutboxOptions(opts ...OutboxOption) BuildOption {

--- a/workflow.go
+++ b/workflow.go
@@ -114,10 +114,12 @@ func (w *Workflow[Type, Status]) Run(ctx context.Context) {
 		w.cancel = cancel
 		w.calledRun = true
 
-		// Start the outbox consumer
-		track(w, func() {
-			outboxConsumer(w, w.outboxConfig)
-		})
+		if !w.outboxConfig.disabled {
+			// Start the outbox consumer
+			track(w, func() {
+				outboxConsumer(w, w.outboxConfig)
+			})
+		}
 
 		// Start the state step consumers
 		for currentStatus, config := range w.consumers {


### PR DESCRIPTION
This MR allows the disabling of the outbox consumer inside workflow. This is desired in the case where the workflow has a record store that purges it's outbox by itself. This is ideal when the record store is centralised for multiple workflows across many services. In cases where a record store is being provisioned locally (same host) or specifaclly for the workflow then the internal outbox consumer should be used for simplicity.