### PR TITLE
adaptertest: Close event producer and consumer at end of test

### DIFF
--- a/adapters/adaptertest/eventstreaming.go
+++ b/adapters/adaptertest/eventstreaming.go
@@ -48,6 +48,10 @@ func RunEventStreamerTest(t *testing.T, factory func() workflow.EventStreamer) {
 		topic := "test-1"
 		sender, err := streamer.NewSender(ctx, topic)
 		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := sender.Close()
+			require.NoError(t, err)
+		})
 
 		err = sender.Send(ctx, "123", 4, map[workflow.Header]string{
 			workflow.HeaderTopic: topic,
@@ -63,6 +67,10 @@ func RunEventStreamerTest(t *testing.T, factory func() workflow.EventStreamer) {
 
 		receiver, err := streamer.NewReceiver(ctx, topic, "my-receiver", workflow.StreamFromLatest())
 		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := receiver.Close()
+			require.NoError(t, err)
+		})
 
 		t.Run("Should only receive events that come in after connecting", func(t *testing.T) {
 			wg.Add(1)
@@ -98,6 +106,10 @@ func RunEventStreamerTest(t *testing.T, factory func() workflow.EventStreamer) {
 
 			secondReceiver, err := streamer.NewReceiver(ctx, topic, "my-receiver", workflow.StreamFromLatest())
 			require.NoError(t, err)
+			t.Cleanup(func() {
+				err := secondReceiver.Close()
+				require.NoError(t, err)
+			})
 
 			// Should receive event send when receiver wasn't receiving events based on the offset being set.
 			e, ack, err := secondReceiver.Recv(ctx)


### PR DESCRIPTION
This properly closes the producer and consumer in the adapter test. This causes goroutine leaks in some implementations as the context is cancelled but the close is not being called which it should.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability and stability of streaming-related tests by adding automatic cleanup hooks to ensure streaming components are closed when tests complete.
  * Reduces flakiness and resource leaks in CI by verifying closures and surface errors on test exit.
  * No changes to application behaviour or user-facing functionality.
  * No impact on public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->