### PR TITLE
workflow/updater: Reject updates if working version changes

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -92,5 +92,5 @@ func processCallback[Type any, Status StatusType](
 		return nil
 	}
 
-	return updater(ctx, currentStatus, next, run)
+	return updater(ctx, currentStatus, next, run, wr.Meta.Version)
 }

--- a/callback_internal_test.go
+++ b/callback_internal_test.go
@@ -60,7 +60,7 @@ func TestProcessCallback(t *testing.T) {
 			return statusEnd, nil
 		})
 
-		updater := func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus]) error {
+		updater := func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus], workingVersion uint) error {
 			calls["updater"] += 1
 			require.Equal(t, "new data", *record.Object)
 			return nil
@@ -100,7 +100,7 @@ func TestProcessCallback(t *testing.T) {
 			return statusEnd, nil
 		})
 
-		updater := func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus]) error {
+		updater := func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus], workingVersion uint) error {
 			calls["updater"] += 1
 			require.Equal(t, "new data", *record.Object)
 			return nil
@@ -139,7 +139,7 @@ func TestProcessCallback(t *testing.T) {
 			return testStatus(SkipTypeDefault), nil
 		})
 
-		updater := func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus]) error {
+		updater := func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus], workingVersion uint) error {
 			calls["updater"] += 1
 			return nil
 		}

--- a/step.go
+++ b/step.go
@@ -204,7 +204,7 @@ func stepConsumer[Type any, Status StatusType](
 			return nil
 		}
 
-		return updater(ctx, Status(record.Status), next, run)
+		return updater(ctx, Status(record.Status), next, run, record.Meta.Version)
 	}
 }
 

--- a/step_internal_test.go
+++ b/step_internal_test.go
@@ -63,7 +63,7 @@ func Test_stepConsumer(t *testing.T) {
 			return statusEnd, nil
 		})
 
-		updater := func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus]) error {
+		updater := func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus], workingVersion uint) error {
 			calls["updater"] += 1
 			require.Equal(t, "new data", *record.Object)
 			return nil
@@ -114,7 +114,7 @@ func Test_stepConsumer(t *testing.T) {
 			return statusEnd, nil
 		})
 
-		updater := func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus]) error {
+		updater := func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus], workingVersion uint) error {
 			calls["updater"] += 1
 			require.Equal(t, "new data", *record.Object)
 			return nil
@@ -164,7 +164,7 @@ func Test_stepConsumer(t *testing.T) {
 			return testStatus(SkipTypeDefault), nil
 		})
 
-		updater := func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus]) error {
+		updater := func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus], workingVersion uint) error {
 			calls["updater"] += 1
 			return nil
 		}
@@ -215,7 +215,7 @@ func Test_stepConsumer(t *testing.T) {
 			return 0, testErr
 		})
 
-		updater := func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus]) error {
+		updater := func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus], workingVersion uint) error {
 			calls["updater"] += 1
 			return nil
 		}

--- a/timeout.go
+++ b/timeout.go
@@ -150,7 +150,7 @@ func processTimeout[Type any, Status StatusType](
 		return nil
 	}
 
-	err = updater(ctx, Status(timeout.Status), next, run)
+	err = updater(ctx, Status(timeout.Status), next, run, record.Meta.Version)
 	if err != nil {
 		return err
 	}

--- a/timeout_internal_test.go
+++ b/timeout_internal_test.go
@@ -30,7 +30,7 @@ func TestProcessTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	type calls struct {
-		updater      func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus]) error
+		updater      func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus], workingVersion uint) error
 		store        func(ctx context.Context, record *Record) error
 		timeoutFunc  func(ctx context.Context, r *Run[string, testStatus], now time.Time) (testStatus, error)
 		completeFunc func(ctx context.Context, id int64) error
@@ -50,7 +50,7 @@ func TestProcessTimeout(t *testing.T) {
 			name: "Golden path consume - initiated",
 			caller: func(call map[string]int) calls {
 				return calls{
-					updater: func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus]) error {
+					updater: func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus], workingVersion uint) error {
 						call["updater"] += 1
 						require.Equal(t, "new data", *record.Object)
 						return nil
@@ -88,7 +88,7 @@ func TestProcessTimeout(t *testing.T) {
 			name: "Golden path consume - running",
 			caller: func(call map[string]int) calls {
 				return calls{
-					updater: func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus]) error {
+					updater: func(ctx context.Context, current testStatus, next testStatus, record *Run[string, testStatus], workingVersion uint) error {
 						call["updater"] += 1
 						require.Equal(t, "new data", *record.Object)
 						return nil


### PR DESCRIPTION
This prevents updates for workflows that have been cancelled or paused. If a long running process is cancelled and then finishes the step successfully it will update the state and runstate. This is due to record meta data and payload updates being batched together. Simplest solution is to check the version before sending the update. Theoretically still possible but much less likely to take place considering the low frequency of these signals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced concurrent update handling with version-based conflict detection. The system now prevents conflicting updates when records are modified simultaneously, returning clear error messages when conflicts occur.
  * Added stricter validation to detect when records have been modified since being loaded, ensuring data consistency across concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->