### PR TITLE
adapters/redis: Rename to wredis

### DIFF
--- a/adapters/wredis/store.go
+++ b/adapters/wredis/store.go
@@ -1,4 +1,4 @@
-package redis
+package wredis
 
 import (
 	"context"

--- a/adapters/wredis/store_test.go
+++ b/adapters/wredis/store_test.go
@@ -1,4 +1,4 @@
-package redis
+package wredis
 
 import (
 	"testing"


### PR DESCRIPTION
Fix the rename of redis to wredis
