### PR TITLE
Fix error counter keying on dynamic error messages

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -10,11 +10,10 @@ var (
 	ErrInvalidTransition    = errors.New("invalid transition")
 )
 
-// ErrorCounter defines an interface for counting occurrences of errors keyed by stable labels.
+// ErrorCounter defines an interface for counting errors keyed by stable labels.
 // At least one label is required — labels should identify the process and run (e.g. processName, runID).
-// The error value is not used for keying because error messages often contain dynamic data.
 type ErrorCounter interface {
-	Add(err error, label string, extras ...string) int
-	Count(err error, label string, extras ...string) int
-	Clear(err error, label string, extras ...string)
+	Add(label string, extras ...string) int
+	Count(label string, extras ...string) int
+	Clear(label string, extras ...string)
 }

--- a/errors.go
+++ b/errors.go
@@ -10,9 +10,11 @@ var (
 	ErrInvalidTransition    = errors.New("invalid transition")
 )
 
-// ErrorCounter defines an interface for counting occurrences of errors with optional labels.
+// ErrorCounter defines an interface for counting occurrences of errors keyed by stable labels.
+// At least one label is required — labels should identify the process and run (e.g. processName, runID).
+// The error value is not used for keying because error messages often contain dynamic data.
 type ErrorCounter interface {
-	Add(err error, labels ...string) int
-	Count(err error, labels ...string) int
-	Clear(err error, labels ...string)
+	Add(err error, label string, extras ...string) int
+	Count(err error, label string, extras ...string) int
+	Clear(err error, label string, extras ...string)
 }

--- a/internal/errorcounter/errorcounter.go
+++ b/internal/errorcounter/errorcounter.go
@@ -16,7 +16,7 @@ type Counter struct {
 	store map[string]int
 }
 
-func (c *Counter) Add(err error, label string, extras ...string) int {
+func (c *Counter) Add(label string, extras ...string) int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -25,7 +25,7 @@ func (c *Counter) Add(err error, label string, extras ...string) int {
 	return c.store[key]
 }
 
-func (c *Counter) Count(err error, label string, extras ...string) int {
+func (c *Counter) Count(label string, extras ...string) int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -33,7 +33,7 @@ func (c *Counter) Count(err error, label string, extras ...string) int {
 	return c.store[key]
 }
 
-func (c *Counter) Clear(err error, label string, extras ...string) {
+func (c *Counter) Clear(label string, extras ...string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -41,9 +41,6 @@ func (c *Counter) Clear(err error, label string, extras ...string) {
 	delete(c.store, key)
 }
 
-// makeKey builds a stable key from labels only. The error message is excluded
-// because it often contains dynamic data (timestamps, IDs) which would create
-// unique keys and prevent the PauseAfterErrCount threshold from ever being reached.
 func makeKey(label string, extras []string) string {
 	if len(extras) == 0 {
 		return label

--- a/internal/errorcounter/errorcounter.go
+++ b/internal/errorcounter/errorcounter.go
@@ -16,34 +16,37 @@ type Counter struct {
 	store map[string]int
 }
 
-func (c *Counter) Add(err error, labels ...string) int {
+func (c *Counter) Add(err error, label string, extras ...string) int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	key := makeKey(labels)
+	key := makeKey(label, extras)
 	c.store[key] += 1
 	return c.store[key]
 }
 
-func (c *Counter) Count(err error, labels ...string) int {
+func (c *Counter) Count(err error, label string, extras ...string) int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	key := makeKey(labels)
+	key := makeKey(label, extras)
 	return c.store[key]
 }
 
-func (c *Counter) Clear(err error, labels ...string) {
+func (c *Counter) Clear(err error, label string, extras ...string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	key := makeKey(labels)
+	key := makeKey(label, extras)
 	delete(c.store, key)
 }
 
 // makeKey builds a stable key from labels only. The error message is excluded
 // because it often contains dynamic data (timestamps, IDs) which would create
 // unique keys and prevent the PauseAfterErrCount threshold from ever being reached.
-func makeKey(labels []string) string {
-	return strings.Join(labels, "-")
+func makeKey(label string, extras []string) string {
+	if len(extras) == 0 {
+		return label
+	}
+	return label + "-" + strings.Join(extras, "-")
 }

--- a/internal/errorcounter/errorcounter.go
+++ b/internal/errorcounter/errorcounter.go
@@ -20,27 +20,30 @@ func (c *Counter) Add(err error, labels ...string) int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	errMsg := err.Error()
-	errMsg += strings.Join(labels, "-")
-	c.store[errMsg] += 1
-	return c.store[errMsg]
+	key := makeKey(labels)
+	c.store[key] += 1
+	return c.store[key]
 }
 
 func (c *Counter) Count(err error, labels ...string) int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	errMsg := err.Error()
-	errMsg += strings.Join(labels, "-")
-	return c.store[errMsg]
+	key := makeKey(labels)
+	return c.store[key]
 }
 
 func (c *Counter) Clear(err error, labels ...string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	errMsg := err.Error()
-	errMsg += strings.Join(labels, "-")
-	c.store[errMsg] = 0
-	return
+	key := makeKey(labels)
+	delete(c.store, key)
+}
+
+// makeKey builds a stable key from labels only. The error message is excluded
+// because it often contains dynamic data (timestamps, IDs) which would create
+// unique keys and prevent the PauseAfterErrCount threshold from ever being reached.
+func makeKey(labels []string) string {
+	return strings.Join(labels, "-")
 }

--- a/internal/errorcounter/errorcounter.go
+++ b/internal/errorcounter/errorcounter.go
@@ -45,5 +45,5 @@ func makeKey(label string, extras []string) string {
 	if len(extras) == 0 {
 		return label
 	}
-	return label + "-" + strings.Join(extras, "-")
+	return label + "\x00" + strings.Join(extras, "\x00")
 }

--- a/internal/errorcounter/errorcounter_test.go
+++ b/internal/errorcounter/errorcounter_test.go
@@ -1,7 +1,6 @@
 package errorcounter_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,75 +11,58 @@ import (
 func TestErrorCounter(t *testing.T) {
 	t.Run("Add 3 and get 3", func(t *testing.T) {
 		c := errorcounter.New()
-		err := errors.New("test error")
 
-		c.Add(err, "label 1", "label 2")
-		c.Add(err, "label 1", "label 2")
-		count := c.Add(err, "label 1", "label 2")
+		c.Add("label 1", "label 2")
+		c.Add("label 1", "label 2")
+		count := c.Add("label 1", "label 2")
 		require.Equal(t, 3, count)
 
-		require.Equal(t, 3, c.Count(err, "label 1", "label 2"))
+		require.Equal(t, 3, c.Count("label 1", "label 2"))
 
-		c.Clear(err, "label 1", "label 2")
-		require.Equal(t, 0, c.Count(err, "label 1", "label 2"))
+		c.Clear("label 1", "label 2")
+		require.Equal(t, 0, c.Count("label 1", "label 2"))
 	})
 
 	t.Run("Single label", func(t *testing.T) {
 		c := errorcounter.New()
-		err := errors.New("test error")
 
-		c.Add(err, "only-label")
-		count := c.Add(err, "only-label")
+		c.Add("only-label")
+		count := c.Add("only-label")
 		require.Equal(t, 2, count)
 
-		require.Equal(t, 2, c.Count(err, "only-label"))
+		require.Equal(t, 2, c.Count("only-label"))
 
-		c.Clear(err, "only-label")
-		require.Equal(t, 0, c.Count(err, "only-label"))
+		c.Clear("only-label")
+		require.Equal(t, 0, c.Count("only-label"))
 	})
 
 	t.Run("Add 0 and get 0", func(t *testing.T) {
 		c := errorcounter.New()
-		require.Equal(t, 0, c.Count(errors.New("test error"), "label 1"))
+		require.Equal(t, 0, c.Count("label 1"))
 	})
-}
-
-func TestErrorCounter_DifferentErrorsSameLabels(t *testing.T) {
-	c := errorcounter.New()
-
-	// Different error messages with the same labels should share a counter.
-	c.Add(errors.New("connection refused at 10:00:01"), "processName", "run-123")
-	c.Add(errors.New("connection refused at 10:00:02"), "processName", "run-123")
-	count := c.Add(errors.New("timeout after 30s"), "processName", "run-123")
-
-	require.Equal(t, 3, count)
-
-	// Count should work regardless of which error is passed.
-	require.Equal(t, 3, c.Count(errors.New("completely different error"), "processName", "run-123"))
 }
 
 func TestErrorCounter_ClearRemovesKey(t *testing.T) {
 	c := errorcounter.New()
 
-	c.Add(errors.New("err"), "process", "run-1")
-	c.Add(errors.New("err"), "process", "run-1")
-	require.Equal(t, 2, c.Count(errors.New("err"), "process", "run-1"))
+	c.Add("process", "run-1")
+	c.Add("process", "run-1")
+	require.Equal(t, 2, c.Count("process", "run-1"))
 
-	c.Clear(errors.New("err"), "process", "run-1")
+	c.Clear("process", "run-1")
 
 	// After clear, count should be 0 and next Add should return 1.
-	require.Equal(t, 0, c.Count(errors.New("err"), "process", "run-1"))
-	require.Equal(t, 1, c.Add(errors.New("err"), "process", "run-1"))
+	require.Equal(t, 0, c.Count("process", "run-1"))
+	require.Equal(t, 1, c.Add("process", "run-1"))
 }
 
 func TestErrorCounter_DifferentLabelsSeparateCounters(t *testing.T) {
 	c := errorcounter.New()
-	err := errors.New("same error")
 
-	c.Add(err, "process-a", "run-1")
-	c.Add(err, "process-a", "run-1")
-	c.Add(err, "process-b", "run-2")
+	c.Add("process-a", "run-1")
+	c.Add("process-a", "run-1")
+	c.Add("process-b", "run-2")
 
-	require.Equal(t, 2, c.Count(err, "process-a", "run-1"))
-	require.Equal(t, 1, c.Count(err, "process-b", "run-2"))
+	require.Equal(t, 2, c.Count("process-a", "run-1"))
+	require.Equal(t, 1, c.Count("process-b", "run-2"))
 }

--- a/internal/errorcounter/errorcounter_test.go
+++ b/internal/errorcounter/errorcounter_test.go
@@ -10,84 +10,67 @@ import (
 )
 
 func TestErrorCounter(t *testing.T) {
-	testCases := []struct {
-		name           string
-		inputErr       error
-		labels         []string
-		iterationCount int
-		expectedCount  int
-	}{
-		{
-			name:           "Add 3 and get 3",
-			inputErr:       errors.New("test error"),
-			labels:         []string{"label 1", "label 2"},
-			iterationCount: 3,
-			expectedCount:  3,
-		},
-		{
-			name:           "Add 1 and get 1 - no labels",
-			inputErr:       errors.New("test error"),
-			labels:         []string{},
-			iterationCount: 3,
-			expectedCount:  3,
-		},
-		{
-			name:           "Add 0 and get 0",
-			inputErr:       errors.New("test error"),
-			labels:         []string{"label 1"},
-			iterationCount: 0,
-			expectedCount:  0,
-		},
-	}
+	t.Run("Add 3 and get 3", func(t *testing.T) {
+		c := errorcounter.New()
+		err := errors.New("test error")
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			c := errorcounter.New()
+		c.Add(err, "label 1", "label 2")
+		c.Add(err, "label 1", "label 2")
+		count := c.Add(err, "label 1", "label 2")
+		require.Equal(t, 3, count)
 
-			var currentCount int
-			for i := 0; i < tc.iterationCount; i++ {
-				currentCount = c.Add(tc.inputErr, tc.labels...)
-			}
-			require.Equal(t, tc.expectedCount, currentCount)
+		require.Equal(t, 3, c.Count(err, "label 1", "label 2"))
 
-			count := c.Count(tc.inputErr, tc.labels...)
-			require.Equal(t, tc.expectedCount, count)
+		c.Clear(err, "label 1", "label 2")
+		require.Equal(t, 0, c.Count(err, "label 1", "label 2"))
+	})
 
-			c.Clear(tc.inputErr, tc.labels...)
-			count = c.Count(tc.inputErr, tc.labels...)
-			require.Equal(t, 0, count)
-		})
-	}
+	t.Run("Single label", func(t *testing.T) {
+		c := errorcounter.New()
+		err := errors.New("test error")
+
+		c.Add(err, "only-label")
+		count := c.Add(err, "only-label")
+		require.Equal(t, 2, count)
+
+		require.Equal(t, 2, c.Count(err, "only-label"))
+
+		c.Clear(err, "only-label")
+		require.Equal(t, 0, c.Count(err, "only-label"))
+	})
+
+	t.Run("Add 0 and get 0", func(t *testing.T) {
+		c := errorcounter.New()
+		require.Equal(t, 0, c.Count(errors.New("test error"), "label 1"))
+	})
 }
 
 func TestErrorCounter_DifferentErrorsSameLabels(t *testing.T) {
 	c := errorcounter.New()
-	labels := []string{"processName", "run-123"}
 
 	// Different error messages with the same labels should share a counter.
-	c.Add(errors.New("connection refused at 10:00:01"), labels...)
-	c.Add(errors.New("connection refused at 10:00:02"), labels...)
-	count := c.Add(errors.New("timeout after 30s"), labels...)
+	c.Add(errors.New("connection refused at 10:00:01"), "processName", "run-123")
+	c.Add(errors.New("connection refused at 10:00:02"), "processName", "run-123")
+	count := c.Add(errors.New("timeout after 30s"), "processName", "run-123")
 
 	require.Equal(t, 3, count)
 
 	// Count should work regardless of which error is passed.
-	require.Equal(t, 3, c.Count(errors.New("completely different error"), labels...))
+	require.Equal(t, 3, c.Count(errors.New("completely different error"), "processName", "run-123"))
 }
 
 func TestErrorCounter_ClearRemovesKey(t *testing.T) {
 	c := errorcounter.New()
-	labels := []string{"process", "run-1"}
 
-	c.Add(errors.New("err"), labels...)
-	c.Add(errors.New("err"), labels...)
-	require.Equal(t, 2, c.Count(errors.New("err"), labels...))
+	c.Add(errors.New("err"), "process", "run-1")
+	c.Add(errors.New("err"), "process", "run-1")
+	require.Equal(t, 2, c.Count(errors.New("err"), "process", "run-1"))
 
-	c.Clear(errors.New("err"), labels...)
+	c.Clear(errors.New("err"), "process", "run-1")
 
 	// After clear, count should be 0 and next Add should return 1.
-	require.Equal(t, 0, c.Count(errors.New("err"), labels...))
-	require.Equal(t, 1, c.Add(errors.New("err"), labels...))
+	require.Equal(t, 0, c.Count(errors.New("err"), "process", "run-1"))
+	require.Equal(t, 1, c.Add(errors.New("err"), "process", "run-1"))
 }
 
 func TestErrorCounter_DifferentLabelsSeparateCounters(t *testing.T) {

--- a/internal/errorcounter/errorcounter_test.go
+++ b/internal/errorcounter/errorcounter_test.go
@@ -59,3 +59,45 @@ func TestErrorCounter(t *testing.T) {
 		})
 	}
 }
+
+func TestErrorCounter_DifferentErrorsSameLabels(t *testing.T) {
+	c := errorcounter.New()
+	labels := []string{"processName", "run-123"}
+
+	// Different error messages with the same labels should share a counter.
+	c.Add(errors.New("connection refused at 10:00:01"), labels...)
+	c.Add(errors.New("connection refused at 10:00:02"), labels...)
+	count := c.Add(errors.New("timeout after 30s"), labels...)
+
+	require.Equal(t, 3, count)
+
+	// Count should work regardless of which error is passed.
+	require.Equal(t, 3, c.Count(errors.New("completely different error"), labels...))
+}
+
+func TestErrorCounter_ClearRemovesKey(t *testing.T) {
+	c := errorcounter.New()
+	labels := []string{"process", "run-1"}
+
+	c.Add(errors.New("err"), labels...)
+	c.Add(errors.New("err"), labels...)
+	require.Equal(t, 2, c.Count(errors.New("err"), labels...))
+
+	c.Clear(errors.New("err"), labels...)
+
+	// After clear, count should be 0 and next Add should return 1.
+	require.Equal(t, 0, c.Count(errors.New("err"), labels...))
+	require.Equal(t, 1, c.Add(errors.New("err"), labels...))
+}
+
+func TestErrorCounter_DifferentLabelsSeparateCounters(t *testing.T) {
+	c := errorcounter.New()
+	err := errors.New("same error")
+
+	c.Add(err, "process-a", "run-1")
+	c.Add(err, "process-a", "run-1")
+	c.Add(err, "process-b", "run-2")
+
+	require.Equal(t, 2, c.Count(err, "process-a", "run-1"))
+	require.Equal(t, 1, c.Count(err, "process-b", "run-2"))
+}

--- a/internal/errorcounter/errorcounter_test.go
+++ b/internal/errorcounter/errorcounter_test.go
@@ -66,3 +66,18 @@ func TestErrorCounter_DifferentLabelsSeparateCounters(t *testing.T) {
 	require.Equal(t, 2, c.Count("process-a", "run-1"))
 	require.Equal(t, 1, c.Count("process-b", "run-2"))
 }
+
+func TestErrorCounter_NoKeyCollision(t *testing.T) {
+	c := errorcounter.New()
+
+	// ("a-b", "c") and ("a", "b-c") must map to distinct keys.
+	c.Add("a-b", "c")
+	c.Add("a", "b-c")
+
+	require.Equal(t, 1, c.Count("a-b", "c"))
+	require.Equal(t, 1, c.Count("a", "b-c"))
+
+	c.Clear("a-b", "c")
+	require.Equal(t, 0, c.Count("a-b", "c"))
+	require.Equal(t, 1, c.Count("a", "b-c"))
+}

--- a/pause.go
+++ b/pause.go
@@ -24,7 +24,7 @@ func maybePause[Type any, Status StatusType](
 		return false, nil
 	}
 
-	count := counter.Add(originalErr, processName, run.RunID)
+	count := counter.Add(processName, run.RunID)
 	if count < pauseAfterErrCount {
 		return false, nil
 	}
@@ -41,7 +41,7 @@ func maybePause[Type any, Status StatusType](
 	})
 
 	// Run paused - now clear the error counter.
-	counter.Clear(originalErr, processName, run.RunID)
+	counter.Clear(processName, run.RunID)
 	return true, nil
 }
 

--- a/pause.go
+++ b/pause.go
@@ -14,7 +14,6 @@ func maybePause[Type any, Status StatusType](
 	ctx context.Context,
 	pauseAfterErrCount int,
 	counter ErrorCounter,
-	originalErr error,
 	processName string,
 	run *Run[Type, Status],
 	logger Logger,

--- a/pause_internal_test.go
+++ b/pause_internal_test.go
@@ -69,9 +69,9 @@ func Test_maybeAutoPause(t *testing.T) {
 				RunID: "run-id",
 			}, "test", WithPauseFn(tc.pauseFn))
 
-			counter.Clear(testErr, processName, r.RunID)
+			counter.Clear(processName, r.RunID)
 			for range tc.errCount {
-				counter.Add(testErr, processName, r.RunID)
+				counter.Add(processName, r.RunID)
 			}
 
 			paused, err := maybePause(

--- a/pause_internal_test.go
+++ b/pause_internal_test.go
@@ -15,7 +15,6 @@ import (
 func Test_maybeAutoPause(t *testing.T) {
 	ctx := t.Context()
 	counter := errorcounter.New()
-	testErr := errors.New("test error")
 	pauseErr := errors.New("pause error")
 	processName := "process"
 
@@ -78,7 +77,6 @@ func Test_maybeAutoPause(t *testing.T) {
 				ctx,
 				tc.pauseAfterErrCount,
 				counter,
-				testErr,
 				processName,
 				r,
 				&logger{},

--- a/step.go
+++ b/step.go
@@ -175,7 +175,7 @@ func stepConsumer[Type any, Status StatusType](
 		next, err := stepLogic(ctx, run)
 		if err != nil {
 			originalErr := err
-			paused, err := maybePause(ctx, pauseAfterErrCount, errorCounter, originalErr, processName, run, logger)
+			paused, err := maybePause(ctx, pauseAfterErrCount, errorCounter, processName, run, logger)
 			if err != nil {
 				return fmt.Errorf("pause error: %v, meta: %v", err, map[string]string{
 					"run_id":     record.RunID,

--- a/step_internal_test.go
+++ b/step_internal_test.go
@@ -208,7 +208,7 @@ func Test_stepConsumer(t *testing.T) {
 	})
 
 	t.Run("Pause record after exceeding allowed error count", func(t *testing.T) {
-		counter.Clear(testErr, processName, current.RunID)
+		counter.Clear(processName, current.RunID)
 
 		calls := map[string]int{
 			"consumerFunc": 0,

--- a/timeout.go
+++ b/timeout.go
@@ -128,7 +128,7 @@ func processTimeout[Type any, Status StatusType](
 
 	next, err := config.TimeoutFunc(ctx, run, w.clock.Now())
 	if err != nil {
-		_, err := maybePause(ctx, pauseAfterErrCount, w.errorCounter, err, processName, run, w.logger)
+		_, err := maybePause(ctx, pauseAfterErrCount, w.errorCounter, processName, run, w.logger)
 		if err != nil {
 			return fmt.Errorf("pause error: %v, meta: %v", err, map[string]string{
 				"run_id":     record.RunID,

--- a/timeout_internal_test.go
+++ b/timeout_internal_test.go
@@ -178,9 +178,9 @@ func TestProcessTimeout(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			counter.Clear(testErr, processName, tc.record.RunID)
+			counter.Clear(processName, tc.record.RunID)
 			for range tc.currentErrCount {
-				counter.Add(testErr, processName, tc.record.RunID)
+				counter.Add(processName, tc.record.RunID)
 			}
 
 			calls := map[string]int{}


### PR DESCRIPTION
## Problem
Error counter uses `err.Error()` as part of the map key. Errors with dynamic content (timestamps, IDs) create unique keys, so `PauseAfterErrCount` threshold is never reached. Also, zeroed keys are never pruned, leaking memory.

## Why
Records that should be paused after N errors retry forever — the safety net silently doesn't work.

## Fix
Key only on labels (processName + runID) which are stable. Use `delete()` instead of zeroing on `Clear()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated error counter usage to rely on a primary stable label with optional extra qualifiers, ensuring consistent keying.
  * Counter reset now fully removes the stored entry for the specified label set.
  * Pause/timeout behaviour is now driven by process/run tracking rather than the presence of a particular error instance.
* **Tests**
  * Adjusted and expanded tests to verify keyed counting, independent counters per label set, correct removal on clear, and updated pause/timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->