### PR TITLE
chore: add auto-approve workflow for Renovate luno dependency updates

### DIFF
--- a/.github/workflows/auto-approve-renovate.yml
+++ b/.github/workflows/auto-approve-renovate.yml
@@ -1,0 +1,13 @@
+name: Auto-approve Renovate
+
+on:
+  pull_request:
+    paths:
+      - '**/go.mod'
+      - '**/go.sum'
+
+jobs:
+  auto-approve:
+    uses: luno/.github/.github/workflows/auto-approve-renovate.yml@bed3271ff217a47465df382ff478db33e79aef1f
+    permissions:
+      pull-requests: write


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-approve-renovate.yml` which auto-approves Renovate PRs that only update `go.mod`/`go.sum` for `github.com/luno/` dependencies
- Uses the shared reusable workflow from `luno/.github`
- Also enables auto-merge on this repository so approved Renovate PRs can merge automatically

## Test plan

- [ ] Verify workflow appears under Actions tab
- [ ] Check that a Renovate luno-dependency PR gets auto-approved