### PR TITLE
adapters: Fix StreamFromLatest race condition

### DIFF
--- a/adapters/adaptertest/eventstreaming.go
+++ b/adapters/adaptertest/eventstreaming.go
@@ -2,7 +2,6 @@ package adaptertest
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -63,8 +62,6 @@ func RunEventStreamerTest(t *testing.T, factory func() workflow.EventStreamer) {
 		})
 		require.NoError(t, err)
 
-		var wg sync.WaitGroup
-
 		receiver, err := streamer.NewReceiver(ctx, topic, "my-receiver", workflow.StreamFromLatest())
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -73,26 +70,17 @@ func RunEventStreamerTest(t *testing.T, factory func() workflow.EventStreamer) {
 		})
 
 		t.Run("Should only receive events that come in after connecting", func(t *testing.T) {
-			wg.Add(1)
-			go func() {
-				go func() {
-					err := sender.Send(ctx, "789", 5, map[workflow.Header]string{
-						workflow.HeaderTopic: topic,
-					})
-					require.NoError(t, err)
-				}()
+			err := sender.Send(ctx, "789", 5, map[workflow.Header]string{
+				workflow.HeaderTopic: topic,
+			})
+			require.NoError(t, err)
 
-				e, ack, err := receiver.Recv(ctx)
-				require.NoError(t, err)
-				require.Equal(t, "789", e.ForeignID)
+			e, ack, err := receiver.Recv(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "789", e.ForeignID)
 
-				err = ack()
-				require.NoError(t, err)
-
-				wg.Done()
-			}()
-
-			wg.Wait()
+			err = ack()
+			require.NoError(t, err)
 		})
 
 		err = receiver.Close()

--- a/adapters/memstreamer/memstreamer.go
+++ b/adapters/memstreamer/memstreamer.go
@@ -76,6 +76,13 @@ func (s StreamConstructor) NewReceiver(
 		opt(&options)
 	}
 
+	// Set the cursor to the current log length at receiver creation time so
+	// that events sent after NewReceiver but before the first Recv are still
+	// received.
+	if options.StreamFromLatest && s.cursorStore.Get(name) == 0 {
+		s.cursorStore.Set(name, len(*s.stream.log))
+	}
+
 	return &Stream{
 		mu:          s.stream.mu,
 		log:         s.stream.log,
@@ -122,11 +129,6 @@ func (s *Stream) Recv(ctx context.Context) (*workflow.Event, workflow.Ack, error
 		s.mu.Unlock()
 
 		cursorOffset := s.cursorStore.Get(s.name)
-		if s.options.StreamFromLatest && cursorOffset == 0 {
-			s.cursorStore.Set(s.name, len(log))
-			continue
-		}
-
 		if len(log)-1 < cursorOffset {
 			continue
 		}

--- a/adapters/reflexstreamer/reflex.go
+++ b/adapters/reflexstreamer/reflex.go
@@ -16,12 +16,30 @@ import (
 	"github.com/luno/workflow"
 )
 
-func New(writer, reader *sql.DB, table *rsql.EventsTable, cursorStore reflex.CursorStore) workflow.EventStreamer {
-	return &constructor{
+func New(writer, reader *sql.DB, table *rsql.EventsTable, cursorStore reflex.CursorStore, opts ...Option) workflow.EventStreamer {
+	c := &constructor{
 		writer:      writer,
 		reader:      reader,
 		eventsTable: table,
 		cursorStore: cursorStore,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Option configures a reflexstreamer constructor.
+type Option func(*constructor)
+
+// WithEventsTableName sets the events table name, enabling StreamFromLatest to
+// resolve the head cursor at NewReceiver time rather than deferring to the
+// first Recv call. Without this option, StreamFromLatest relies on
+// reflex.WithStreamFromHead which resolves the head on first Recv, creating a
+// race window where events sent between NewReceiver and Recv may be skipped.
+func WithEventsTableName(name string) Option {
+	return func(c *constructor) {
+		c.eventsTableName = name
 	}
 }
 
@@ -30,6 +48,7 @@ type constructor struct {
 	reader            *sql.DB
 	stream            reflex.StreamFunc
 	eventsTable       *rsql.EventsTable
+	eventsTableName   string
 	cursorStore       reflex.CursorStore
 	registerGapFiller sync.Once
 }
@@ -98,7 +117,23 @@ func (c *constructor) NewReceiver(
 
 	var streamOpts []reflex.StreamOption
 	if copts.StreamFromLatest && cursor == "" {
-		streamOpts = append(streamOpts, reflex.WithStreamFromHead())
+		if c.eventsTableName != "" {
+			// Resolve head cursor now so events sent between NewReceiver
+			// and the first Recv call are not skipped.
+			var maxID sql.NullInt64
+			err := c.reader.QueryRowContext(ctx,
+				"select max(id) from "+c.eventsTableName,
+			).Scan(&maxID)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get latest event id")
+			}
+			if maxID.Valid && maxID.Int64 > 0 {
+				cursor = strconv.FormatInt(maxID.Int64, 10)
+			}
+		} else {
+			// Fallback: resolve head on first Recv (has a small race window).
+			streamOpts = append(streamOpts, reflex.WithStreamFromHead())
+		}
 	}
 
 	streamClient, err := table.ToStream(c.reader)(ctx, cursor, streamOpts...)

--- a/adapters/reflexstreamer/reflex.go
+++ b/adapters/reflexstreamer/reflex.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"io"
+	"regexp"
 	"strconv"
 	"sync"
 	"time"
@@ -15,6 +16,9 @@ import (
 	"github.com/luno/reflex/rsql"
 	"github.com/luno/workflow"
 )
+
+// validIdentifier matches safe SQL table/column names (letter or underscore start, alphanumerics/underscores only).
+var validIdentifier = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
 func New(writer, reader *sql.DB, table *rsql.EventsTable, cursorStore reflex.CursorStore, opts ...Option) workflow.EventStreamer {
 	c := &constructor{
@@ -118,11 +122,14 @@ func (c *constructor) NewReceiver(
 	var streamOpts []reflex.StreamOption
 	if copts.StreamFromLatest && cursor == "" {
 		if c.eventsTableName != "" {
+			if !validIdentifier.MatchString(c.eventsTableName) {
+				return nil, errors.New("invalid events table name")
+			}
 			// Resolve head cursor now so events sent between NewReceiver
 			// and the first Recv call are not skipped.
 			var maxID sql.NullInt64
 			err := c.reader.QueryRowContext(ctx,
-				"select max(id) from "+c.eventsTableName,
+				"select max(id) from `"+c.eventsTableName+"`",
 			).Scan(&maxID)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get latest event id")

--- a/adapters/reflexstreamer/reflex_test.go
+++ b/adapters/reflexstreamer/reflex_test.go
@@ -18,7 +18,7 @@ func TestStreamer(t *testing.T) {
 	dbc := ConnectForTesting(t)
 	cTable := rsql.NewCursorsTable("cursors")
 	adaptertest.RunEventStreamerTest(t, func() workflow.EventStreamer {
-		return reflexstreamer.New(dbc, dbc, eventsTable, cTable.ToStore(dbc))
+		return reflexstreamer.New(dbc, dbc, eventsTable, cTable.ToStore(dbc), reflexstreamer.WithEventsTableName("workflow_events"))
 	})
 }
 

--- a/adapters/wredis/streamer.go
+++ b/adapters/wredis/streamer.go
@@ -42,6 +42,24 @@ func (s *Streamer) NewReceiver(ctx context.Context, topic string, name string, o
 		opt(&options)
 	}
 
+	streamKey := streamKeyPrefix + topic
+	consumerGroup := consumerGroupPrefix + name
+
+	// Determine the starting position for the consumer group.
+	// When StreamFromLatest is set we start from "$" (end of stream at this
+	// moment) so that only events sent AFTER NewReceiver returns are delivered.
+	// Creating the group here — rather than lazily inside Recv — eliminates the
+	// race where events arrive between NewReceiver and the first Recv call.
+	startID := "0"
+	if options.StreamFromLatest {
+		startID = "$"
+	}
+
+	err := s.client.XGroupCreateMkStream(ctx, streamKey, consumerGroup, startID).Err()
+	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
+		return nil, err
+	}
+
 	return &Receiver{
 		client:  s.client,
 		topic:   topic,
@@ -99,38 +117,6 @@ var _ workflow.EventReceiver = (*Receiver)(nil)
 func (r *Receiver) Recv(ctx context.Context) (*workflow.Event, workflow.Ack, error) {
 	streamKey := streamKeyPrefix + r.topic
 	consumerGroup := consumerGroupPrefix + r.name
-
-	// Handle StreamFromLatest option by checking if consumer group exists
-	if r.options.StreamFromLatest {
-		// Try to get consumer group info to see if it exists
-		groups, err := r.client.XInfoGroups(ctx, streamKey).Result()
-		if err != nil && err.Error() != "ERR no such key" {
-			return nil, nil, err
-		}
-
-		groupExists := false
-		for _, group := range groups {
-			if group.Name == consumerGroup {
-				groupExists = true
-				break
-			}
-		}
-
-		if !groupExists {
-			// Consumer group doesn't exist, create it starting from the latest message
-			// Use "$" to start from the end of the stream
-			_, err := r.client.XGroupCreateMkStream(ctx, streamKey, consumerGroup, "$").Result()
-			if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
-				return nil, nil, err
-			}
-		}
-	} else {
-		// Create consumer group if it doesn't exist, starting from beginning
-		_, err := r.client.XGroupCreateMkStream(ctx, streamKey, consumerGroup, "0").Result()
-		if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
-			return nil, nil, err
-		}
-	}
 
 	for ctx.Err() == nil {
 		// First, try to read pending messages that were delivered but not acknowledged

--- a/adapters/wredis/streamer.go
+++ b/adapters/wredis/streamer.go
@@ -56,7 +56,7 @@ func (s *Streamer) NewReceiver(ctx context.Context, topic string, name string, o
 	}
 
 	err := s.client.XGroupCreateMkStream(ctx, streamKey, consumerGroup, startID).Err()
-	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
+	if err != nil && !strings.HasPrefix(err.Error(), "BUSYGROUP") {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

`StreamFromLatest` was resolving the "latest" cursor position on the first `Recv()` call instead of at `NewReceiver()` time. This created a race where events sent between `NewReceiver` and the first `Recv` could be skipped — or cause `Recv` to hang indefinitely waiting for events that were already in the log/table.

This was causing flaky test failures in downstream consumers (e.g. timing out after 5 minutes in CI).

### Changes

| Adapter | Fix |
|---------|-----|
| **memstreamer** | Set cursor to current log length in `NewReceiver()` instead of first `Recv()` |
| **reflexstreamer** | New `WithEventsTableName` option resolves HEAD via `SELECT MAX(id)` at `NewReceiver()` time. Without the option, falls back to existing `WithStreamFromHead()` behaviour |
| **adaptertest** | Simplified `StreamFromLatest` test — send synchronously before `Recv` (now safe with cursor fix). Removed goroutines + `sync.WaitGroup` |

### Test plan

- [x] `go test ./adapters/memstreamer/... -count=10` passes
- [x] `go test ./adapters/reflexstreamer/... -count=10` passes (including gap filler test)
- [x] Previously-hanging memstreamer test now completes immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable events-table name for the event streamer, with validation and explicit error feedback.

* **Bug Fixes**
  * Receivers now initialise their cursor on creation to avoid races when starting from latest events.
  * Messaging consumer groups are created eagerly with the appropriate start position, reducing first-read races and tolerant handling of existing groups.

* **Tests**
  * Simplified event-streaming test to use a sequential send/receive flow (removed concurrent synchronisation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->