### PR TITLE
ci: test latest Go only and bump go.mod to 1.26.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,6 @@ on:
 jobs:
 
   core:
-    strategy:
-      matrix:
-        go: [ '1.24', '1' ]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -20,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version: '1'
 
       - name: Vet
         run: go vet -v ./...
@@ -72,11 +69,11 @@ jobs:
       - name: Test Kafka Adapter with Testcontainers
         run: |
           cd ./adapters/kafkastreamer
-          echo "🚀 Testing Kafka adapter with testcontainers..."
+          echo "Testing Kafka adapter with testcontainers..."
           go test -v -timeout=10m ./...
 
       - name: Test Redis Adapter with Testcontainers
         run: |
           cd ./adapters/wredis
-          echo "🚀 Testing Redis adapter with testcontainers..."
+          echo "Testing Redis adapter with testcontainers..."
           go test -v -timeout=10m ./...

--- a/_examples/callback/go.mod
+++ b/_examples/callback/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/_examples/callback
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/_examples/connector/go.mod
+++ b/_examples/connector/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/_examples/connector
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/_examples/gettingstarted/go.mod
+++ b/_examples/gettingstarted/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/_examples/gettingstarted
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/_examples/orderprocessor/go.mod
+++ b/_examples/orderprocessor/go.mod
@@ -1,6 +1,6 @@
 module orderprocessor
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/_examples/schedule/go.mod
+++ b/_examples/schedule/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/_examples/schedule
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/_examples/sqlexample/go.mod
+++ b/_examples/sqlexample/go.mod
@@ -1,6 +1,6 @@
 module example.com/sqlexample
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/_examples/timeout/go.mod
+++ b/_examples/timeout/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/_examples/timeout
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/_examples/webui/go.mod
+++ b/_examples/webui/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/_examples/webui
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/jlog/go.mod
+++ b/adapters/jlog/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/adapters/jlog
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/kafkastreamer/go.mod
+++ b/adapters/kafkastreamer/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/adapters/kafkastreamer
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/reflexstreamer/go.mod
+++ b/adapters/reflexstreamer/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/adapters/reflexstreamer
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/rinkrolescheduler/go.mod
+++ b/adapters/rinkrolescheduler/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/adapters/rinkrolescheduler
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/sqlstore/go.mod
+++ b/adapters/sqlstore/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/adapters/sqlstore
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/sqltimeout/go.mod
+++ b/adapters/sqltimeout/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/adapters/sqltimeout
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/webui/go.mod
+++ b/adapters/webui/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/adapters/webui
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/adapters/wredis/go.mod
+++ b/adapters/wredis/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow/adapters/wredis
 
-go 1.25.3
+go 1.26.0
 
 replace github.com/luno/workflow => ../..
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/workflow
 
-go 1.25.3
+go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Simplify the CI test matrix to only test with the latest Go (`'1'`), and bump the `go` directive in `go.mod` to `1.26.0`.

Testing multiple Go versions caused flaky failures whenever we bumped deps ahead of the oldest supported version. Since we don't commit to long-term compatibility with older Go releases, there's no value in the matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain requirement to version 1.26.0 across all modules and examples.
  * Adjusted CI workflow configuration for consistency and added trailing newline formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->