### PR TITLE
fix(memstreamer): park Recv on sync.Cond instead of busy-spin

### DIFF
--- a/adapters/memstreamer/memstreamer.go
+++ b/adapters/memstreamer/memstreamer.go
@@ -22,11 +22,13 @@ func New(opts ...Option) *StreamConstructor {
 		option(&opt)
 	}
 
+	mu := &sync.Mutex{}
 	return &StreamConstructor{
 		opts: &opt,
 		stream: &Stream{
-			mu:  &sync.Mutex{},
-			log: &log,
+			mu:   mu,
+			cond: sync.NewCond(mu),
+			log:  &log,
 		},
 		cursorStore: newCursorStore(),
 	}
@@ -56,6 +58,7 @@ func (s StreamConstructor) NewSender(ctx context.Context, topic string) (workflo
 
 	return &Stream{
 		mu:    s.stream.mu,
+		cond:  s.stream.cond,
 		log:   s.stream.log,
 		topic: topic,
 		clock: s.opts.clock,
@@ -85,6 +88,7 @@ func (s StreamConstructor) NewReceiver(
 
 	return &Stream{
 		mu:          s.stream.mu,
+		cond:        s.stream.cond,
 		log:         s.stream.log,
 		cursorStore: s.cursorStore,
 		topic:       topic,
@@ -98,6 +102,7 @@ var _ workflow.EventStreamer = (*StreamConstructor)(nil)
 
 type Stream struct {
 	mu          *sync.Mutex
+	cond        *sync.Cond
 	log         *[]*workflow.Event
 	cursorStore *cursorStore
 	topic       string
@@ -119,35 +124,65 @@ func (s *Stream) Send(ctx context.Context, foreignID string, statusType int, hea
 		CreatedAt: s.clock.Now(),
 	})
 
+	// Wake any receivers parked on cond.Wait so they can pick up the new event.
+	s.cond.Broadcast()
+
 	return nil
 }
 
 func (s *Stream) Recv(ctx context.Context) (*workflow.Event, workflow.Ack, error) {
-	for ctx.Err() == nil {
-		s.mu.Lock()
-		log := *s.log
-		s.mu.Unlock()
+	// sync.Cond doesn't natively respect ctx. Spawn a watcher that
+	// broadcasts when the ctx is done so Recv can wake up and return
+	// ctx.Err() instead of leaking the goroutine forever. The stop channel
+	// is closed on return so the watcher exits when Recv exits (no leak per
+	// call).
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.mu.Lock()
+			s.cond.Broadcast()
+			s.mu.Unlock()
+		case <-stop:
+		}
+	}()
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+
+		log := *s.log
 		cursorOffset := s.cursorStore.Get(s.name)
+
 		if len(log)-1 < cursorOffset {
+			// Nothing to deliver — park until Send or ctx cancel signals us.
+			s.cond.Wait()
 			continue
 		}
 
 		e := log[cursorOffset]
 
-		// Skip events that are not related to this topic
+		// Skip events that are not related to this topic. Advance the cursor
+		// past the skipped event so we don't see it again.
 		if s.topic != e.Headers[workflow.HeaderTopic] {
 			s.cursorStore.Set(s.name, cursorOffset+1)
 			continue
 		}
 
+		// The ack closure captures cursorOffset so a double-call is a no-op
+		// (it would set the cursor to the same value). The cursorStore's
+		// own mutex protects the cursor map; that's separate from s.mu so
+		// we don't need to hold s.mu here.
 		return e, func() error {
 			s.cursorStore.Set(s.name, cursorOffset+1)
 			return nil
 		}, nil
 	}
-
-	return nil, nil, ctx.Err()
 }
 
 func (s *Stream) Close() error {

--- a/adapters/memstreamer/memstreamer_test.go
+++ b/adapters/memstreamer/memstreamer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -35,7 +36,11 @@ func TestConnector(t *testing.T) {
 func TestRecv_DoesNotBusySpin(t *testing.T) {
 	s := memstreamer.New()
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	var wg sync.WaitGroup
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
 
 	const consumers = 8
 	for i := 0; i < consumers; i++ {
@@ -44,7 +49,9 @@ func TestRecv_DoesNotBusySpin(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewReceiver: %v", err)
 		}
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			for {
 				_, _, err := rec.Recv(ctx)
 				if err != nil {
@@ -155,6 +162,8 @@ func TestRecv_WakesOnCtxCancel(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = rec.Close() })
 
+	before := runtime.NumGoroutine()
+
 	done := make(chan error, 1)
 	go func() {
 		_, _, err := rec.Recv(ctx)
@@ -164,7 +173,6 @@ func TestRecv_WakesOnCtxCancel(t *testing.T) {
 	// Let it park.
 	time.Sleep(20 * time.Millisecond)
 
-	before := runtime.NumGoroutine()
 	cancelAt := time.Now()
 	cancel()
 

--- a/adapters/memstreamer/memstreamer_test.go
+++ b/adapters/memstreamer/memstreamer_test.go
@@ -1,12 +1,18 @@
 package memstreamer_test
 
 import (
+	"context"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/luno/workflow"
 	"github.com/luno/workflow/adapters/adaptertest"
 	"github.com/luno/workflow/adapters/memstreamer"
 )
+
+const testTopic = "test-topic"
 
 func TestStreamer(t *testing.T) {
 	adaptertest.RunEventStreamerTest(t, func() workflow.EventStreamer {
@@ -18,4 +24,166 @@ func TestConnector(t *testing.T) {
 	adaptertest.RunConnectorTest(t, func(seedEvents []workflow.ConnectorEvent) workflow.ConnectorConstructor {
 		return memstreamer.NewConnector(seedEvents)
 	})
+}
+
+// TestRecv_DoesNotBusySpin verifies the headline fix: with several receivers
+// parked and no senders, the goroutine count stays flat AND the receivers
+// are sleeping on sync.Cond rather than spinning runnable. The busy-loop
+// implementation kept goroutine count stable too, so the test also inspects
+// goroutine stacks to confirm they are parked on cond.Wait (semaphore wait)
+// rather than in the middle of the Recv for-loop.
+func TestRecv_DoesNotBusySpin(t *testing.T) {
+	s := memstreamer.New()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const consumers = 8
+	for i := 0; i < consumers; i++ {
+		name := "consumer-" + string(rune('a'+i))
+		rec, err := s.NewReceiver(ctx, testTopic, name)
+		if err != nil {
+			t.Fatalf("NewReceiver: %v", err)
+		}
+		go func() {
+			for {
+				_, _, err := rec.Recv(ctx)
+				if err != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	// Let consumers settle into cond.Wait.
+	time.Sleep(100 * time.Millisecond)
+
+	before := runtime.NumGoroutine()
+	time.Sleep(200 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	// Each Recv call internally spawns a ctx-watcher goroutine that lives
+	// for the duration of the Recv call. With no Sends arriving the
+	// receivers stay parked and goroutine count should be stable.
+	if after > before+2 { // +2 wiggle for the test runtime itself
+		t.Errorf("goroutine count grew while idle: before=%d after=%d", before, after)
+	}
+
+	// Verify receivers are parked, not busy-spinning. Dump all goroutine
+	// stacks and assert that there are at least `consumers` goroutines
+	// suspended on memstreamer.(*Stream).Recv via sync.Cond.Wait /
+	// semaphore wait. Under the old busy-loop the Recv goroutines would
+	// be in a runnable for-loop and would NOT show up as waiting in a
+	// sync primitive inside Recv.
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	stacks := string(buf[:n])
+	parked := strings.Count(stacks, "memstreamer.(*Stream).Recv")
+	// Each Recv goroutine appears once; we expect at least `consumers`
+	// stacks pointing into Recv, all in a wait state (sync.runtime_*).
+	if parked < consumers {
+		t.Errorf("expected %d goroutines parked in Recv, found %d in stacks", consumers, parked)
+	}
+	if !strings.Contains(stacks, "sync.runtime_notifyListWait") &&
+		!strings.Contains(stacks, "sync.(*Cond).Wait") {
+		t.Errorf("no goroutines parked on sync.Cond.Wait — Recv may be busy-spinning. Stacks:\n%s", stacks)
+	}
+}
+
+// TestRecv_WakesOnSend asserts that a parked Recv returns promptly after a
+// Send arrives. With the old busy-loop implementation the test still passed
+// (because the loop polled the log), but it would also burn CPU for the
+// 50ms park-window. With cond.Broadcast the wake is event-driven.
+func TestRecv_WakesOnSend(t *testing.T) {
+	s := memstreamer.New()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rec, err := s.NewReceiver(ctx, testTopic, "wake-on-send")
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+
+	got := make(chan *workflow.Event, 1)
+	go func() {
+		e, ack, err := rec.Recv(ctx)
+		if err != nil {
+			return
+		}
+		_ = ack()
+		got <- e
+	}()
+
+	// Give the Recv goroutine time to enter cond.Wait.
+	time.Sleep(50 * time.Millisecond)
+
+	send, err := s.NewSender(ctx, testTopic)
+	if err != nil {
+		t.Fatalf("NewSender: %v", err)
+	}
+	t.Cleanup(func() { _ = send.Close() })
+
+	sendAt := time.Now()
+	if err := send.Send(ctx, "fid-1", 42, map[workflow.Header]string{
+		workflow.HeaderTopic: testTopic,
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	select {
+	case e := <-got:
+		if elapsed := time.Since(sendAt); elapsed > 100*time.Millisecond {
+			t.Errorf("Recv took %v to wake after Send (want <100ms)", elapsed)
+		}
+		if e.ForeignID != "fid-1" {
+			t.Errorf("ForeignID: want fid-1, got %q", e.ForeignID)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("Recv did not unblock within 1s of Send")
+	}
+}
+
+// TestRecv_WakesOnCtxCancel verifies that ctx cancellation wakes a parked
+// Recv promptly and that the ctx-watcher goroutine does not leak per call.
+func TestRecv_WakesOnCtxCancel(t *testing.T) {
+	s := memstreamer.New()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	rec, err := s.NewReceiver(ctx, testTopic, "wake-on-cancel")
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := rec.Recv(ctx)
+		done <- err
+	}()
+
+	// Let it park.
+	time.Sleep(20 * time.Millisecond)
+
+	before := runtime.NumGoroutine()
+	cancelAt := time.Now()
+	cancel()
+
+	select {
+	case err := <-done:
+		if elapsed := time.Since(cancelAt); elapsed > 100*time.Millisecond {
+			t.Errorf("Recv took %v to wake after cancel (want <100ms)", elapsed)
+		}
+		if err == nil {
+			t.Errorf("Recv should return ctx.Err(), got nil")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("Recv did not unblock on ctx cancel within 500ms")
+	}
+
+	// Give the watcher goroutine a moment to exit after Recv returns.
+	time.Sleep(50 * time.Millisecond)
+	after := runtime.NumGoroutine()
+	if after > before {
+		t.Errorf("goroutine leak after ctx cancel: before=%d after=%d", before, after)
+	}
 }

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -179,9 +180,9 @@ func TestWorkflow_ScheduleFilter(t *testing.T) {
 	wf.Run(ctx)
 	t.Cleanup(wf.Stop)
 
-	shouldSkip := false
+	var shouldSkip atomic.Bool
 	filter := func(ctx context.Context) (bool, error) {
-		return !shouldSkip, nil
+		return !shouldSkip.Load(), nil
 	}
 	opt := workflow.WithScheduleFilter[MyType, status](filter)
 
@@ -218,7 +219,7 @@ func TestWorkflow_ScheduleFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test 2: Filter blocks scheduling (shouldSkip = true)
-	shouldSkip = true
+	shouldSkip.Store(true)
 
 	// Move to June 1st - second scheduled time, but filter should block it
 	expectedTimestamp = time.Date(2023, time.June, 1, 0, 0, 0, 0, time.UTC)
@@ -233,7 +234,7 @@ func TestWorkflow_ScheduleFilter(t *testing.T) {
 	require.Equal(t, firstRun.RunID, latest.RunID, "No new run should be created when filter returns false")
 
 	// Test 3: Filter allows scheduling again (shouldSkip = false)
-	shouldSkip = false
+	shouldSkip.Store(false)
 
 	// Move to July 1st - third scheduled time, filter should allow it
 	expectedTimestamp = time.Date(2023, time.July, 1, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary

`adapters/memstreamer/(*Stream).Recv` polls the in-memory log in an unconditional `for { ... continue }` loop with no backoff. Each iteration acquires and releases `s.mu` and `cursorStore.mu`. With *N* step consumers per workflow, every iteration of the runtime scheduler keeps all *N* goroutines runnable on those two mutexes — even when there is nothing to deliver.

In a downstream daemon ([everflow](https://github.com/andrewwormald/everflow)) using `memstreamer` as the production `EventStreamer` (durability already provided by a sqlite-backed `RecordStore` + transactional outbox), this pinned an Apple Silicon laptop at ~380% CPU for 15+ hours, even after the single in-flight Run had already reached a terminal status and the event log was no longer growing. A SIGQUIT goroutine dump showed all step consumers in `runnable` state inside `(*cursorStore).Get → Mutex.lockSlow`.

This PR replaces the busy loop with `sync.Cond` parking: `Recv` blocks on `cond.Wait` when there's nothing to deliver and is woken by `cond.Broadcast` on `Send`.

## What changed

- **`adapters/memstreamer/memstreamer.go`**
  - Added `cond *sync.Cond` to the shared `Stream` struct, constructed once in `New()` keyed off the existing shared `s.mu`. Sender + receiver `Stream`s share the same cond pointer (same wiring pattern as `mu` and `log`).
  - `Send` calls `s.cond.Broadcast()` while still holding `s.mu` — the natural place after appending.
  - `Recv` holds `s.mu` across the for-loop; when the log is exhausted it calls `s.cond.Wait()` instead of `continue`. Topic-skip still advances the cursor and loops without parking.
  - A per-call watcher goroutine selects on `<-ctx.Done()` vs `<-stop`; on ctx done it locks `s.mu`, broadcasts, unlocks. `defer close(stop)` ensures the watcher exits when `Recv` returns — no per-call leak.

- **`adapters/memstreamer/memstreamer_test.go`** — three new regression tests:
  - `TestRecv_DoesNotBusySpin` — 8 parked receivers; asserts `runtime.NumGoroutine()` stable over 200 ms AND dumps `runtime.Stack` to assert at least 8 stacks point into `memstreamer.(*Stream).Recv` and at least one is in `sync.runtime_notifyListWait` / `sync.(*Cond).Wait`. The stack-shape assertion is what actually distinguishes spin from park.
  - `TestRecv_WakesOnSend` — parked `Recv` returns within 100 ms of a `Send`.
  - `TestRecv_WakesOnCtxCancel` — parked `Recv` returns `ctx.Err()` within 100 ms of cancel; `NumGoroutine` does not grow after cancel (no watcher leak).

## Semantics preserved

- Public interfaces unchanged: `StreamConstructor.NewSender`, `NewReceiver`, `Send`, `Recv`, `Close`, the ack closure, and the `WithClock` option are all identical. No new exported symbols or options.
- Topic filtering, per-receiver cursor advancement via `cursorStore`, `StreamFromLatest` option, and the idempotent ack-closure-advances-cursor-exactly-once semantics all behave the same.
- Lock order unchanged: `Recv` takes `s.mu` (across the wait); the ack closure only touches `cursorStore.mu`; `Send` takes `s.mu` (briefly) and broadcasts.

## Verification

`go test ./adapters/memstreamer/... -count=1 -race`:
```
--- PASS: TestStreamer (1.02s)
--- PASS: TestConnector (0.26s)
--- PASS: TestRecv_DoesNotBusySpin (0.30s)
--- PASS: TestRecv_WakesOnSend (0.05s)
--- PASS: TestRecv_WakesOnCtxCancel (0.07s)
ok  	github.com/luno/workflow/adapters/memstreamer	2.94s
```

`go test ./... -count=1 -race` — all packages green (~23s), including the workflow consumer paths that exercise the adapter.

I verified that the **new tests fail against the original busy-loop implementation** by stashing the fix and re-running: `TestRecv_DoesNotBusySpin` dumped goroutines stuck in `internal/sync.(*Mutex).lockSlow` in the `runnable` state inside `Recv` (matching exactly the SIGQUIT dump described above) before failing.

## Behavioural notes

- **Wakeup ordering / fairness:** `cond.Broadcast()` wakes all parked receivers; they then race for `s.mu`. The Go runtime does not guarantee FIFO order on `sync.Mutex.Lock`. The previous busy-loop had no fairness either (all goroutines hammered the mutex), so this is no worse — but consumers should not depend on a particular wake order. For per-receiver cursor independence (multiple `name`s, same topic) this is fine because each receiver has its own cursor in `cursorStore`.
- **Per-call ctx watcher:** every `Recv` invocation now spawns one ephemeral goroutine. Workflow consumers typically call `Recv` in a tight loop (one event at a time), so this is one short-lived goroutine per delivered event — bounded by event throughput, cleaned up via `defer close(stop)`. Negligible compared to the CPU saved.
- **Lock held across Wait:** `s.cond.Wait()` releases `s.mu` while parked and reacquires on wake. `Send` is not blocked by parked receivers.

## Test plan

- [x] `go test ./adapters/memstreamer/... -race`
- [x] `go test ./... -race`
- [x] Reverse-verify: stash the fix, re-run; new tests fail as expected
- [ ] (Reviewer) Confirm no consumer in the codebase depends on FIFO wakeup order across multiple `Recv` callers on the same topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming so waiting receivers sleep efficiently using condition-based signalling instead of busy-spinning.
  * Sends now notify waiting receivers immediately; cancelling a receiver context reliably unblocks `Recv` promptly, reducing latency and avoiding goroutine leaks. Event delivery and acknowledgement semantics remain unchanged.
* **Tests**
  * Expanded memstreamer `Recv` coverage for idle behaviour, wake-up on send, and context cancellation; adjusted schedule filtering test to use atomic state for stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->