### PR TITLE
webui: wire up topbar search and fetch foreign ID matches server-side

### DIFF
--- a/adapters/webui/internal/frontend/home.html
+++ b/adapters/webui/internal/frontend/home.html
@@ -832,7 +832,7 @@ function Sidebar({ stateCounts, activeNav, onNav, presetCount = 0, workflowCount
 }
 
 /* ---- Topbar ---- */
-function Topbar({ theme, setTheme, polling, onTogglePolling, activeNav = "runs" }) {
+function Topbar({ theme, setTheme, polling, onTogglePolling, activeNav = "runs", search = "", onSearch }) {
   const crumbMap = { runs: "Runs", workflows: "Workflows", saved: "Saved filters", docs: "Docs", settings: "Settings" };
   return (
     <header className="topbar">
@@ -843,8 +843,9 @@ function Topbar({ theme, setTheme, polling, onTogglePolling, activeNav = "runs" 
       </div>
       <div className="topbar-search">
         <Icon name="search" />
-        <input placeholder="Search runs, workflows, foreign IDs…" />
-        <span className="kbd">⌘K</span>
+        <input placeholder="Search by foreign ID…" value={search}
+               onChange={e => onSearch && onSearch(e.target.value)} />
+        <span className="kbd">/</span>
       </div>
       <div className="topbar-actions">
         <button className="icon-btn" title="Live polling" onClick={onTogglePolling}>
@@ -1828,15 +1829,27 @@ const REFRESH_INTERVALS = [
   { key: 30000, label: "30s" },
 ];
 
-async function apiFetchRuns() {
+async function apiFetchList(overrides) {
   const resp = await fetch(API.list, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ offset: 0, limit: 500, order: "desc" }),
+    body: JSON.stringify({ offset: 0, limit: 500, order: "desc", ...overrides }),
   });
   if (!resp.ok) throw new Error(`List failed: ${resp.status}`);
   const data = await resp.json();
   return data.items || [];
+}
+
+// The base list only covers the newest 500 runs, so a foreign ID search would
+// silently miss older runs. When a foreign ID is set, also fetch exact matches
+// server-side and merge them in.
+async function apiFetchRuns(foreignId) {
+  const requests = [apiFetchList({})];
+  if (foreignId) requests.push(apiFetchList({ filter_by_foreign_id: foreignId }));
+  const results = await Promise.all(requests);
+  const byRunId = new Map();
+  for (const r of results.flat()) byRunId.set(r.run_id, r);
+  return [...byRunId.values()];
 }
 
 async function apiUpdate(runId, action) {
@@ -1883,13 +1896,20 @@ function App() {
 
   useEffect(() => { localStorage.setItem("wf.presets", JSON.stringify(presets)); }, [presets]);
 
+  // Debounced so typing a foreign ID doesn't fire a server request per keystroke.
+  const [debouncedForeignId, setDebouncedForeignId] = useState(filters.foreignId);
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedForeignId(filters.foreignId), 300);
+    return () => clearTimeout(id);
+  }, [filters.foreignId]);
+
   const doFetch = useCallback(async () => {
     setLoading(true);
     setFetchError(null);
-    try { setRecords(await apiFetchRuns()); }
+    try { setRecords(await apiFetchRuns(debouncedForeignId)); }
     catch (e) { setFetchError(e.message); }
     finally { setLoading(false); }
-  }, []);
+  }, [debouncedForeignId]);
 
   useEffect(() => {
     if (activeNav !== "runs") return;
@@ -1962,7 +1982,8 @@ function App() {
   return (
     <div className="app">
       <Sidebar stateCounts={stateCounts} activeNav={activeNav} onNav={setActiveNav} presetCount={presets.length} workflowCount={workflowCount} />
-      <Topbar theme={theme} setTheme={v => setTweak("theme", v)} polling={polling} onTogglePolling={() => setPolling(p => !p)} activeNav={activeNav} />
+      <Topbar theme={theme} setTheme={v => setTweak("theme", v)} polling={polling} onTogglePolling={() => setPolling(p => !p)} activeNav={activeNav}
+              search={filters.foreignId} onSearch={foreignId => setFilters(f => ({ ...f, foreignId }))} />
 
       <main className="main">
         {activeNav === "runs" && (

--- a/adapters/webui/internal/frontend/home.html
+++ b/adapters/webui/internal/frontend/home.html
@@ -1808,7 +1808,7 @@ Object.assign(window, { WorkflowsView, SavedFiltersView, DocsView, SettingsView 
 </script>
 
 <script type="text/babel">
-const { useState, useEffect, useMemo, useCallback } = React;
+const { useState, useEffect, useMemo, useCallback, useRef } = React;
 
 const API = window.__API_PATHS || { list: "", update: "", objectData: "" };
 
@@ -1903,12 +1903,23 @@ function App() {
     return () => clearTimeout(id);
   }, [filters.foreignId]);
 
+  // Concurrent fetches can resolve out of order (debounced search vs polling);
+  // only the latest request may write state, or stale results overwrite fresh ones.
+  const fetchId = useRef(0);
   const doFetch = useCallback(async () => {
+    const currentFetch = ++fetchId.current;
     setLoading(true);
     setFetchError(null);
-    try { setRecords(await apiFetchRuns(debouncedForeignId)); }
-    catch (e) { setFetchError(e.message); }
-    finally { setLoading(false); }
+    try {
+      const records = await apiFetchRuns(debouncedForeignId);
+      if (currentFetch === fetchId.current) setRecords(records);
+    }
+    catch (e) {
+      if (currentFetch === fetchId.current) setFetchError(e.message);
+    }
+    finally {
+      if (currentFetch === fetchId.current) setLoading(false);
+    }
   }, [debouncedForeignId]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Bind the topbar search input to the foreign ID filter: it previously had no `value` or `onChange` handlers, so typing into it never sent a request
- Fetch exact foreign ID matches server-side via `filter_by_foreign_id` and merge them into the base list by `run_id`, so runs older than the newest 500 are findable by full foreign ID
- Debounce the refetch by 300ms so typing does not fire a request per keystroke
- Correct the misleading hints: placeholder now says the input searches foreign IDs, and the shortcut badge shows `/` (the implemented focus shortcut) instead of Cmd+K

## What changed

- `adapters/webui/internal/frontend/home.html`: split `apiFetchRuns` into `apiFetchList` plus a merging wrapper, add debounced `filters.foreignId` state feeding `doFetch`, wire `Topbar` search to the shared filter state

## Verification

- Headless Chrome against `_examples/webui`: typing `Customer 2` into the topbar search sends `{"filter_by_foreign_id":"Customer 2"}` to the list endpoint and the table narrows to that run; the same interaction on the previous code sent no request at all
- `go build ./...` and `go test ./...` pass in `adapters/webui`; all embedded JSX blocks compile under Babel

## Limitations

- Server-side foreign ID filtering is exact match, so a partial foreign ID still only narrows the newest 500 runs client-side; the full ID always finds the run regardless of age

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a controlled foreign-ID search field to the top navigation bar.
  - Updated the top bar UX with “/” keyboard indicator for faster search access.
  - Search results now include older exact matches in addition to the newest entries.

- **Performance**
  - Debounced foreign-ID search input to reduce unnecessary server requests.
  - Prevented out-of-order results from overwriting newer state by guarding async updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->